### PR TITLE
Added ZIL opcode names to the Table of Opcodes

### DIFF
--- a/sect14.html
+++ b/sect14.html
@@ -36,128 +36,128 @@
 
 <caption><strong>Two-operand opcodes 2OP</strong></caption>
 
-<tr><td>   St</td><td>  Br</td><td>  Opcode</td><td> Hex </td><td> V  </td><td>Inform name and syntax  </td><td>Link</td></tr>
-<tr><td>     </td><td>    </td><td>  ------</td><td>   0 </td><td> ---</td><td>---</td><td></td></tr>
+<tr><td>   St</td><td>  Br</td><td>  Opcode</td><td> Hex </td><td> V  </td><td>Inform name and syntax  </td><td>ZIL name</td><td>Link</td></tr>
+<tr><td>     </td><td>    </td><td>  ------</td><td>   0 </td><td> ---</td><td>---</td><td></td><td></td></tr>
 
 <tr><td>     </td><td>  * </td><td>  2OP:1 </td><td>   1 </td><td>    </td>
-    <td>je              a b c d ?(label)</td><td><a href="sect15.html#je"><strong>je              </strong></a></td>
+    <td>je              a b c d ?(label)</td><td>XXX</td><td><a href="sect15.html#je"><strong>je              </strong></a></td>
 </tr>
 
 <tr><td>     </td><td>  * </td><td>  2OP:2 </td><td>   2 </td><td>    </td>
-    <td>jl              a b ?(label)</td><td><a href="sect15.html#jl"><strong>jl              </strong></a></td>
+    <td>jl              a b ?(label)</td><td>XXX</td><td><a href="sect15.html#jl"><strong>jl              </strong></a></td>
 </tr>
 
 <tr><td>     </td><td>  * </td><td>  2OP:3 </td><td>   3 </td><td>    </td><td>jg              a b ?(label)</td>
-    <td><a href="sect15.html#jg"><strong>jg              </strong></a></td>
+    <td>XXX</td><td><a href="sect15.html#jg"><strong>jg              </strong></a></td>
 </tr>
 
 <tr><td>     </td><td>  * </td><td>  2OP:4 </td><td>   4 </td><td>    </td><td>dec_chk         (variable) value ?(label)</td>
-    <td><a href="sect15.html#dec_chk"><strong>dec_chk         </strong></a></td>
+    <td>XXX</td><td><a href="sect15.html#dec_chk"><strong>dec_chk         </strong></a></td>
 </tr>
 
 <tr><td>     </td><td>  * </td><td>  2OP:5 </td><td>   5 </td><td>    </td><td>inc_chk         (variable) value ?(label)</td>
-    <td><a href="sect15.html#inc_chk"><strong>inc_chk         </strong></a></td>
+    <td>XXX</td><td><a href="sect15.html#inc_chk"><strong>inc_chk         </strong></a></td>
 </tr>
 
 <tr><td>     </td><td>  * </td><td>  2OP:6 </td><td>   6 </td><td>    </td><td>jin             obj1 obj2 ?(label)</td>
-    <td><a href="sect15.html#jin"><strong>jin             </strong></a></td>
+    <td>XXX</td><td><a href="sect15.html#jin"><strong>jin             </strong></a></td>
 </tr>
 
 <tr><td>     </td><td>  * </td><td>  2OP:7 </td><td>   7 </td><td>    </td><td>test            bitmap flags ?(label)</td>
-    <td><a href="sect15.html#test"><strong>test            </strong></a></td>
+    <td>XXX</td><td><a href="sect15.html#test"><strong>test            </strong></a></td>
 </tr>
 
 <tr><td>   * </td><td>    </td><td>  2OP:8 </td><td>   8 </td><td>    </td><td>or              a b -> (result)</td>
-    <td><a href="sect15.html#or"><strong>or              </strong></a></td>
+    <td>XXX</td><td><a href="sect15.html#or"><strong>or              </strong></a></td>
 </tr>
 
 <tr><td>   * </td><td>    </td><td>  2OP:9 </td><td>   9 </td><td>    </td><td>and             a b -> (result)</td>
-    <td><a href="sect15.html#and"><strong>and             </strong></a></td>
+    <td>XXX</td><td><a href="sect15.html#and"><strong>and             </strong></a></td>
 </tr>
 
 <tr><td>     </td><td>  * </td><td>  2OP:10</td><td>   A </td><td>    </td><td>test_attr       object attribute ?(label)</td>
-    <td><a href="sect15.html#test_attr"><strong>test_attr       </strong></a></td>
+    <td>XXX</td><td><a href="sect15.html#test_attr"><strong>test_attr       </strong></a></td>
 </tr>
 
 <tr><td>     </td><td>    </td><td>  2OP:11</td><td>   B </td><td>    </td><td>set_attr        object attribute</td>
-    <td><a href="sect15.html#set_attr"><strong>set_attr        </strong></a></td>
+    <td>XXX</td><td><a href="sect15.html#set_attr"><strong>set_attr        </strong></a></td>
 </tr>
 
 <tr><td>     </td><td>    </td><td>  2OP:12</td><td>   C </td><td>    </td><td>clear_attr      object attribute</td>
-    <td><a href="sect15.html#clear_attr"><strong>clear_attr      </strong></a></td>
+    <td>XXX</td><td><a href="sect15.html#clear_attr"><strong>clear_attr      </strong></a></td>
 </tr>
 
 <tr><td>     </td><td>    </td><td>  2OP:13</td><td>   D </td><td>    </td><td>store           (variable) value</td>
-    <td><a href="sect15.html#store"><strong>store           </strong></a></td>
+    <td>XXX</td><td><a href="sect15.html#store"><strong>store           </strong></a></td>
 </tr>
 
 <tr><td>     </td><td>    </td><td>  2OP:14</td><td>   E </td><td>    </td><td>insert_obj      object destination</td>
-    <td><a href="sect15.html#insert_obj"><strong>insert_obj      </strong></a></td>
+    <td>XXX</td><td><a href="sect15.html#insert_obj"><strong>insert_obj      </strong></a></td>
 </tr>
 
 <tr><td>   * </td><td>    </td><td>  2OP:15</td><td>   F </td><td>    </td><td>loadw           array word-index -> (result)</td>
-    <td><a href="sect15.html#loadw"><strong>loadw           </strong></a></td>
+    <td>XXX</td><td><a href="sect15.html#loadw"><strong>loadw           </strong></a></td>
 </tr>
 
 <tr><td>   * </td><td>    </td><td>  2OP:16</td><td>  10 </td><td>    </td><td>loadb           array byte-index -> (result)</td>
-    <td><a href="sect15.html#loadb"><strong>loadb           </strong></a></td>
+    <td>XXX</td><td><a href="sect15.html#loadb"><strong>loadb           </strong></a></td>
 </tr>
 
 <tr><td>   * </td><td>    </td><td>  2OP:17</td><td>  11 </td><td>    </td><td>get_prop        object property -> (result)</td>
-    <td><a href="sect15.html#get_prop"><strong>get_prop        </strong></a></td>
+    <td>XXX</td><td><a href="sect15.html#get_prop"><strong>get_prop        </strong></a></td>
 </tr>
 
 <tr><td>   * </td><td>    </td><td>  2OP:18</td><td>  12 </td><td>    </td><td>get_prop_addr   object property -> (result)</td>
-    <td><a href="sect15.html#get_prop_addr"><strong>get_prop_addr   </strong></a></td>
+    <td>XXX</td><td><a href="sect15.html#get_prop_addr"><strong>get_prop_addr   </strong></a></td>
 </tr>
 
 <tr><td>   * </td><td>    </td><td>  2OP:19</td><td>  13 </td><td>    </td><td>get_next_prop   object property -> (result)</td>
-    <td><a href="sect15.html#get_next_prop"><strong>get_next_prop   </strong></a></td>
+    <td>XXX</td><td><a href="sect15.html#get_next_prop"><strong>get_next_prop   </strong></a></td>
 </tr>
 
 <tr><td>   * </td><td>    </td><td>  2OP:20</td><td>  14 </td><td>    </td><td>add             a b -> (result)</td>
-    <td><a href="sect15.html#add"><strong>add             </strong></a></td>
+    <td>XXX</td><td><a href="sect15.html#add"><strong>add             </strong></a></td>
 </tr>
 
 <tr><td>   * </td><td>    </td><td>  2OP:21</td><td>  15 </td><td>    </td><td>sub             a b -> (result)</td>
-    <td><a href="sect15.html#sub"><strong>sub             </strong></a></td>
+    <td>XXX</td><td><a href="sect15.html#sub"><strong>sub             </strong></a></td>
 </tr>
 
 <tr><td>   * </td><td>    </td><td>  2OP:22</td><td>  16 </td><td>    </td><td>mul             a b -> (result)</td>
-    <td><a href="sect15.html#mul"><strong>mul             </strong></a></td>
+    <td>XXX</td><td><a href="sect15.html#mul"><strong>mul             </strong></a></td>
 </tr>
 
 <tr><td>   * </td><td>    </td><td>  2OP:23</td><td>  17 </td><td>    </td><td>div             a b -> (result)</td>
-    <td><a href="sect15.html#div"><strong>div             </strong></a></td></tr>
+    <td>XXX</td><td><a href="sect15.html#div"><strong>div             </strong></a></td></tr>
 
 <tr><td>   * </td><td>    </td><td>  2OP:24</td><td>  18 </td><td>    </td><td>mod             a b -> (result)</td>
-    <td><a href="sect15.html#mod"><strong>mod             </strong></a></td>
+    <td>XXX</td><td><a href="sect15.html#mod"><strong>mod             </strong></a></td>
 </tr>
 
 <tr><td>   * </td><td>    </td><td>  2OP:25</td><td>  19 </td><td> 4  </td><td>call_2s         routine arg1 -> (result)</td>
-    <td><a href="sect15.html#call_2s"><strong>call_2s         </strong></a></td>
+    <td>XXX</td><td><a href="sect15.html#call_2s"><strong>call_2s         </strong></a></td>
 </tr>
 
 <tr><td>     </td><td>    </td><td>  2OP:26</td><td>  1A </td><td> 5  </td><td>call_2n         routine arg1</td>
-    <td><a href="sect15.html#call_2n"><strong>call_2n         </strong></a></td>
+    <td>XXX</td><td><a href="sect15.html#call_2n"><strong>call_2n         </strong></a></td>
 </tr>
 
 <tr><td>     </td><td>    </td><td>  2OP:27</td><td>  1B </td><td> 5  </td><td>set_colour      foreground background</td>
-    <td><a href="sect15.html#set_colour"><strong>set_colour</strong></a></td>
+    <td>XXX</td><td><a href="sect15.html#set_colour"><strong>set_colour</strong></a></td>
 </tr>
 
 <tr><td>     </td><td>    </td><td>        </td><td>     </td><td> 6  </td><td>set_colour      foreground background window</td>
-    <td><a href="sect15.html#set_colour"><strong>set_colour</strong></a></td>
+    <td>XXX</td><td><a href="sect15.html#set_colour"><strong>set_colour</strong></a></td>
 </tr>
 
 <tr><td>     </td><td>    </td><td>  2OP:28</td><td>  1C </td><td>5/6 </td><td>throw           value stack-frame</td>
-    <td><a href="sect15.html#throw"><strong>throw           </strong></a></td>
+    <td>XXX</td><td><a href="sect15.html#throw"><strong>throw           </strong></a></td>
 </tr>
 
-<tr><td>     </td><td>    </td><td>  ------</td><td>  1D </td><td> ---</td><td>---</td><td></td></tr>
-<tr><td>     </td><td>    </td><td>  ------</td><td>  1E </td><td> ---</td><td>---</td><td></td></tr>
-<tr><td>     </td><td>    </td><td>  ------</td><td>  1F </td><td> ---</td><td>---</td><td></td></tr>
-<tr><td colspan="7" class="note">Opcode numbers 32 to 127: other forms of 2OP with different types.</td></tr>
+<tr><td>     </td><td>    </td><td>  ------</td><td>  1D </td><td> ---</td><td>---</td><td></td><td></td></tr>
+<tr><td>     </td><td>    </td><td>  ------</td><td>  1E </td><td> ---</td><td>---</td><td></td><td></td></tr>
+<tr><td>     </td><td>    </td><td>  ------</td><td>  1F </td><td> ---</td><td>---</td><td></td><td></td></tr>
+<tr><td colspan="8" class="note">Opcode numbers 32 to 127: other forms of 2OP with different types.</td></tr>
 </table>
 
 
@@ -165,77 +165,77 @@
 
 <caption><strong>One-operand opcodes 1OP</strong></caption>
 
-<tr><td>   St</td><td>  Br</td><td>  Opcode</td><td> Hex </td><td> V  </td><td>Inform name and syntax  </td><td>Link</td></tr>
+<tr><td>   St</td><td>  Br</td><td>  Opcode</td><td> Hex </td><td> V  </td><td>Inform name and syntax  </td><td>ZIL name</td><td>Link</td></tr>
 
 <tr><td>     </td><td>  * </td><td>  1OP:128</td><td>  0 </td><td>    </td><td>jz              a ?(label)</td>
-    <td><a href="sect15.html#jz"><strong>jz              </strong></a></td>
+    <td>XXX</td><td><a href="sect15.html#jz"><strong>jz              </strong></a></td>
 </tr>
 
 <tr><td>   * </td><td>  * </td><td>  1OP:129</td><td>  1 </td><td>    </td><td>get_sibling     object -> (result) ?(label)</td>
-    <td><a href="sect15.html#get_sibling"><strong>get_sibling     </strong></a></td>
+    <td>XXX</td><td><a href="sect15.html#get_sibling"><strong>get_sibling     </strong></a></td>
 </tr>
 
 <tr><td>   * </td><td>  * </td><td>  1OP:130</td><td>  2 </td><td>    </td><td>get_child       object -> (result) ?(label)</td>
-    <td><a href="sect15.html#get_child"><strong>get_child       </strong></a></td>
+    <td>XXX</td><td><a href="sect15.html#get_child"><strong>get_child       </strong></a></td>
 </tr>
 
 <tr><td>   * </td><td>    </td><td>  1OP:131</td><td>  3 </td><td>    </td><td>get_parent      object -> (result)</td>
-    <td><a href="sect15.html#get_parent"><strong>get_parent      </strong></a></td>
+    <td>XXX</td><td><a href="sect15.html#get_parent"><strong>get_parent      </strong></a></td>
 </tr>
 
 <tr><td>   * </td><td>    </td><td>  1OP:132</td><td>  4 </td><td>    </td><td>get_prop_len    property-address -> (result)</td>
-    <td><a href="sect15.html#get_prop_len"><strong>get_prop_len    </strong></a></td>
+    <td>XXX</td><td><a href="sect15.html#get_prop_len"><strong>get_prop_len    </strong></a></td>
 </tr>
 
 <tr><td>     </td><td>    </td><td>  1OP:133</td><td>  5 </td><td>    </td><td>inc             (variable)</td>
-    <td><a href="sect15.html#inc"><strong>inc             </strong></a></td>
+    <td>XXX</td><td><a href="sect15.html#inc"><strong>inc             </strong></a></td>
 </tr>
 
 <tr><td>     </td><td>    </td><td>  1OP:134</td><td>  6 </td><td>    </td><td>dec             (variable)</td>
-    <td><a href="sect15.html#dec"><strong>dec             </strong></a></td>
+    <td>XXX</td><td><a href="sect15.html#dec"><strong>dec             </strong></a></td>
 </tr>
 
 <tr><td>     </td><td>    </td><td>  1OP:135</td><td>  7 </td><td>    </td><td>print_addr      byte-address-of-string</td>
-    <td><a href="sect15.html#print_addr"><strong>print_addr      </strong></a></td>
+    <td>XXX</td><td><a href="sect15.html#print_addr"><strong>print_addr      </strong></a></td>
 </tr>
 
 <tr><td>   * </td><td>    </td><td>  1OP:136</td><td>  8 </td><td> 4  </td><td>call_1s         routine -> (result)</td>
-    <td><a href="sect15.html#call_1s"><strong>call_1s         </strong></a></td>
+    <td>XXX</td><td><a href="sect15.html#call_1s"><strong>call_1s         </strong></a></td>
 </tr>
 
 <tr><td>     </td><td>    </td><td>  1OP:137</td><td>  9 </td><td>    </td><td>remove_obj      object</td>
-    <td><a href="sect15.html#remove_obj"><strong>remove_obj      </strong></a></td>
+    <td>XXX</td><td><a href="sect15.html#remove_obj"><strong>remove_obj      </strong></a></td>
 </tr>
 
 <tr><td>     </td><td>    </td><td>  1OP:138</td><td>  A </td><td>    </td><td>print_obj       object</td>
-    <td><a href="sect15.html#print_obj"><strong>print_obj       </strong></a></td>
+    <td>XXX</td><td><a href="sect15.html#print_obj"><strong>print_obj       </strong></a></td>
 </tr>
 
 <tr><td>     </td><td>    </td><td>  1OP:139</td><td>  B </td><td>    </td><td>ret             value</td>
-    <td><a href="sect15.html#ret"><strong>ret             </strong></a></td>
+    <td>XXX</td><td><a href="sect15.html#ret"><strong>ret             </strong></a></td>
 </tr>
 
 <tr><td>     </td><td>    </td><td>  1OP:140</td><td>  C </td><td>    </td><td>jump            ?(label)</td>
-    <td><a href="sect15.html#jump"><strong>jump            </strong></a></td>
+    <td>XXX</td><td><a href="sect15.html#jump"><strong>jump            </strong></a></td>
 </tr>
 
 <tr><td>     </td><td>    </td><td>  1OP:141</td><td>  D </td><td>    </td><td>print_paddr     packed-address-of-string</td>
-    <td><a href="sect15.html#print_paddr"><strong>print_paddr     </strong></a></td>
+    <td>XXX</td><td><a href="sect15.html#print_paddr"><strong>print_paddr     </strong></a></td>
 </tr>
 
 <tr><td>   * </td><td>    </td><td>  1OP:142</td><td>  E </td><td>    </td><td>load            (variable) -> (result)</td>
-    <td><a href="sect15.html#load"><strong>load            </strong></a></td>
+    <td>XXX</td><td><a href="sect15.html#load"><strong>load            </strong></a></td>
 </tr>
 
 <tr><td>   * </td><td>    </td><td>  1OP:143</td><td>  F </td><td>1/4 </td><td>not             value -> (result)</td>
-    <td><a href="sect15.html#not"><strong>not             </strong></a></td>
+    <td>XXX</td><td><a href="sect15.html#not"><strong>not             </strong></a></td>
 </tr>
 
 <tr><td>     </td><td>    </td><td>        </td><td>     </td><td> 5  </td><td>call_1n         routine</td>
-    <td><a href="sect15.html#call_1n"><strong>call_1n         </strong></a></td>
+    <td>XXX</td><td><a href="sect15.html#call_1n"><strong>call_1n         </strong></a></td>
 </tr>
 
-<tr><td colspan="7" class="note">Opcode numbers 144 to 175: other forms of 1OP with different types.</td></tr>
+<tr><td colspan="8" class="note">Opcode numbers 144 to 175: other forms of 1OP with different types.</td></tr>
 
 </table>
 
@@ -245,89 +245,89 @@
 
 <caption><strong>Zero-operand opcodes 0OP</strong></caption>
 
-<tr><td>   St</td><td>  Br</td><td>  Opcode</td><td> Hex </td><td> V  </td><td>Inform name and syntax  </td><td>Link</td></tr>
+<tr><td>   St</td><td>  Br</td><td>  Opcode</td><td> Hex </td><td> V  </td><td>Inform name and syntax  </td><td>ZIL name</td><td>Link</td></tr>
 
 <tr><td>     </td><td>    </td><td>  0OP:176</td><td>  0 </td><td>    </td><td>rtrue</td>
-    <td><a href="sect15.html#rtrue"><strong>rtrue</strong></a></td>
+    <td>XXX</td><td><a href="sect15.html#rtrue"><strong>rtrue</strong></a></td>
 </tr>
 
 <tr><td>     </td><td>    </td><td>  0OP:177</td><td>  1 </td><td>    </td><td>rfalse</td>
-    <td><a href="sect15.html#rfalse"><strong>rfalse</strong></a></td>
+    <td>XXX</td><td><a href="sect15.html#rfalse"><strong>rfalse</strong></a></td>
 </tr>
 
 <tr><td>     </td><td>    </td><td>  0OP:178</td><td>  2 </td><td>    </td>
-    <td>print           (literal-string)</td><td><a href="sect15.html#print"><strong>print           </strong></a></td>
+    <td>print           (literal-string)</td><td>XXX</td><td><a href="sect15.html#print"><strong>print           </strong></a></td>
 </tr>
 
 <tr><td>     </td><td>    </td><td>  0OP:179</td><td>  3 </td><td>    </td>
-    <td>print_ret       (literal-string)</td><td><a href="sect15.html#print_ret"><strong>print_ret       </strong></a></td>
+    <td>print_ret       (literal-string)</td><td>XXX</td><td><a href="sect15.html#print_ret"><strong>print_ret       </strong></a></td>
 </tr>
 
-<tr><td>     </td><td>    </td><td>  0OP:180</td><td>  4 </td><td>1/- </td><td>nop</td><td><a href="sect15.html#nop"><strong>nop</strong></a></td></tr>
+<tr><td>     </td><td>    </td><td>  0OP:180</td><td>  4 </td><td>1/- </td><td>nop</td><td>XXX</td><td><a href="sect15.html#nop"><strong>nop</strong></a></td></tr>
 
 <tr><td>     </td><td>  * </td><td>  0OP:181</td><td>  5 </td><td> 1  </td>
-    <td>save            ?(label)</td><td><a href="sect15.html#save"><strong>save            </strong></a></td>
+    <td>save            ?(label)</td><td>XXX</td><td><a href="sect15.html#save"><strong>save            </strong></a></td>
 </tr>
 
 <tr><td>   * </td><td>    </td><td>        </td><td>     </td><td> 4  </td><td>save            -> (result)</td>
-    <td><a href="sect15.html#save"><strong>save            </strong></a></td>
+    <td>XXX</td><td><a href="sect15.html#save"><strong>save            </strong></a></td>
 </tr>
 
-<tr><td>     </td><td>    </td><td>        </td><td>     </td><td> 5  </td><td>[illegal]</td><td></td></tr>
+<tr><td>     </td><td>    </td><td>        </td><td>     </td><td> 5  </td><td>[illegal]</td><td></td><td></td></tr>
 
 <tr><td>     </td><td>  * </td><td>  0OP:182</td><td>  6 </td><td> 1  </td><td>restore         ?(label)</td>
-    <td><a href="sect15.html#restore"><strong>restore         </strong></a></td>
+    <td>XXX</td><td><a href="sect15.html#restore"><strong>restore         </strong></a></td>
 </tr>
 
 <tr><td>   * </td><td>    </td><td>        </td><td>     </td><td> 4  </td><td>restore         -> (result)</td>
-    <td><a href="sect15.html#restore"><strong>restore         </strong></a></td>
+    <td>XXX</td><td><a href="sect15.html#restore"><strong>restore         </strong></a></td>
 </tr>
 
-<tr><td>     </td><td>    </td><td>        </td><td>     </td><td> 5  </td><td>[illegal]</td><td></td></tr>
+<tr><td>     </td><td>    </td><td>        </td><td>     </td><td> 5  </td><td>[illegal]</td><td></td><td></td></tr>
 
 <tr><td>     </td><td>    </td><td>  0OP:183</td><td>  7 </td><td>    </td><td>restart</td>
-    <td><a href="sect15.html#restart"><strong>restart</strong></a></td>
+    <td>XXX</td><td><a href="sect15.html#restart"><strong>restart</strong></a></td>
 </tr>
 
 <tr><td>     </td><td>    </td><td>  0OP:184</td><td>  8 </td><td>    </td><td>ret_popped</td>
-    <td><a href="sect15.html#ret_popped"><strong>ret_popped</strong></a></td>
+    <td>XXX</td><td><a href="sect15.html#ret_popped"><strong>ret_popped</strong></a></td>
 </tr>
 
 <tr><td>     </td><td>    </td><td>  0OP:185</td><td>  9 </td><td> 1  </td><td>pop</td>
-    <td><a href="sect15.html#pop"><strong>pop</strong></a></td>
+    <td>XXX</td><td><a href="sect15.html#pop"><strong>pop</strong></a></td>
 </tr>
 
 <tr><td>   * </td><td>    </td><td>        </td><td>     </td><td>5/6 </td><td>catch           -> (result)</td>
-    <td><a href="sect15.html#catch"><strong>catch           </strong></a></td>
+    <td>XXX</td><td><a href="sect15.html#catch"><strong>catch           </strong></a></td>
 </tr>
 
 <tr><td>     </td><td>    </td><td>  0OP:186</td><td>  A </td><td>    </td><td>quit</td>
-    <td><a href="sect15.html#quit"><strong>quit</strong></a></td>
+    <td>XXX</td><td><a href="sect15.html#quit"><strong>quit</strong></a></td>
 </tr>
 
 <tr><td>     </td><td>    </td><td>  0OP:187</td><td>  B </td><td>    </td><td>new_line</td>
-    <td><a href="sect15.html#new_line"><strong>new_line</strong></a></td>
+    <td>XXX</td><td><a href="sect15.html#new_line"><strong>new_line</strong></a></td>
 </tr>
 
 <tr><td>     </td><td>    </td><td>  0OP:188</td><td>  C </td><td> 3  </td><td>show_status</td>
-    <td><a href="sect15.html#show_status"><strong>show_status</strong></a></td>
+    <td>XXX</td><td><a href="sect15.html#show_status"><strong>show_status</strong></a></td>
 </tr>
 
-<tr><td>     </td><td>    </td><td>        </td><td>     </td><td> 4  </td><td>[illegal]</td><td></td></tr>
+<tr><td>     </td><td>    </td><td>        </td><td>     </td><td> 4  </td><td>[illegal]</td><td></td><td></td></tr>
 
 <tr><td>     </td><td>  * </td><td>  0OP:189</td><td>  D </td><td> 3  </td><td>verify          ?(label)</td>
-    <td><a href="sect15.html#verify"><strong>verify          </strong></a></td>
+    <td>XXX</td><td><a href="sect15.html#verify"><strong>verify          </strong></a></td>
 </tr>
 
 <tr><td>     </td><td>    </td><td>  0OP:190</td><td>  E </td><td> 5  </td><td>[first byte of extended opcode]</td>
-    <td><a href="sect15.html#extended"><strong>extended</strong></a></td>
+    <td>XXX</td><td><a href="sect15.html#extended"><strong>extended</strong></a></td>
 </tr>
 
 <tr><td>     </td><td>  * </td><td>  0OP:191</td><td>  F </td><td>5/- </td><td>piracy          ?(label)</td>
-    <td><a href="sect15.html#piracy"><strong>piracy          </strong></a></td>
+    <td>XXX</td><td><a href="sect15.html#piracy"><strong>piracy          </strong></a></td>
 </tr>
 
-<tr><td colspan="7" class="note">Opcode numbers 192 to 223: VAR forms of 2OP:0 to 2OP:31.</td></tr>
+<tr><td colspan="8" class="note">Opcode numbers 192 to 223: VAR forms of 2OP:0 to 2OP:31.</td></tr>
 
 </table>
 
@@ -335,170 +335,170 @@
 
 <caption><strong>Variable-operand opcodes VAR</strong></caption>
 
-<tr><td>   St</td><td>  Br</td><td>  Opcode</td><td> Hex </td><td> V  </td><td>Inform name and syntax  </td><td>Link</td></tr>
+<tr><td>   St</td><td>  Br</td><td>  Opcode</td><td> Hex </td><td> V  </td><td>Inform name and syntax  </td><td>ZIL name</td><td>Link</td></tr>
 
 <tr><td>   * </td><td>    </td><td>  VAR:224</td><td>  0 </td><td> 1  </td><td>call            routine ...0 to 3 args... -> (result)</td>
-    <td><a href="sect15.html#call"><strong>call            </strong></a></td>
+    <td>XXX</td><td><a href="sect15.html#call"><strong>call            </strong></a></td>
 </tr>
 
 <tr><td>   * </td><td>    </td><td>        </td><td>     </td><td> 4  </td><td>call_vs         routine ...0 to 3 args... -> (result)</td>
-    <td><a href="sect15.html#call_vs"><strong>call_vs         </strong></a></td>
+    <td>XXX</td><td><a href="sect15.html#call_vs"><strong>call_vs         </strong></a></td>
 </tr>
 
 <tr><td>     </td><td>    </td><td>  VAR:225</td><td>  1 </td><td>    </td><td>storew          array word-index value</td>
-    <td><a href="sect15.html#storew"><strong>storew          </strong></a></td>
+    <td>XXX</td><td><a href="sect15.html#storew"><strong>storew          </strong></a></td>
 </tr>
 
 <tr><td>     </td><td>    </td><td>  VAR:226</td><td>  2 </td><td>    </td><td>storeb          array byte-index value</td>
-    <td><a href="sect15.html#storeb"><strong>storeb          </strong></a></td>
+    <td>XXX</td><td><a href="sect15.html#storeb"><strong>storeb          </strong></a></td>
 </tr>
 
 <tr><td>     </td><td>    </td><td>  VAR:227</td><td>  3 </td><td>    </td><td>put_prop        object property value</td>
-    <td><a href="sect15.html#put_prop"><strong>put_prop        </strong></a></td>
+    <td>XXX</td><td><a href="sect15.html#put_prop"><strong>put_prop        </strong></a></td>
 </tr>
 
 <tr><td>     </td><td>    </td><td>  VAR:228</td><td>  4 </td><td> 1  </td><td>sread           text parse</td>
-    <td><a href="sect15.html#sread"><strong>sread           </strong></a></td>
+    <td>XXX</td><td><a href="sect15.html#sread"><strong>sread           </strong></a></td>
 </tr>
 
 <tr><td>     </td><td>    </td><td>        </td><td>     </td><td> 4  </td><td>sread           text parse time routine</td>
-    <td><a href="sect15.html#sread"><strong>sread           </strong></a></td>
+    <td>XXX</td><td><a href="sect15.html#sread"><strong>sread           </strong></a></td>
 </tr>
 
 <tr><td>   * </td><td>    </td><td>        </td><td>     </td><td> 5  </td><td>aread           text parse time routine -> (result)</td>
-    <td><a href="sect15.html#aread"><strong>aread           </strong></a></td>
+    <td>XXX</td><td><a href="sect15.html#aread"><strong>aread           </strong></a></td>
 </tr>
 
 <tr><td>     </td><td>    </td><td>  VAR:229</td><td>  5 </td><td>    </td><td>print_char      output-character-code</td>
-    <td><a href="sect15.html#print_char"><strong>print_char      </strong></a></td>
+    <td>XXX</td><td><a href="sect15.html#print_char"><strong>print_char      </strong></a></td>
 </tr>
 
 <tr><td>     </td><td>    </td><td>  VAR:230</td><td>  6 </td><td>    </td><td>print_num       value</td>
-    <td><a href="sect15.html#print_num"><strong>print_num       </strong></a></td>
+    <td>XXX</td><td><a href="sect15.html#print_num"><strong>print_num       </strong></a></td>
 </tr>
 
 <tr><td>   * </td><td>    </td><td>  VAR:231</td><td>  7 </td><td>    </td><td>random          range -> (result)</td>
-    <td><a href="sect15.html#random"><strong>random          </strong></a></td>
+    <td>XXX</td><td><a href="sect15.html#random"><strong>random          </strong></a></td>
 </tr>
 
 <tr><td>     </td><td>    </td><td>  VAR:232</td><td>  8 </td><td>    </td><td>push            value</td>
-    <td><a href="sect15.html#push"><strong>push            </strong></a></td>
+    <td>XXX</td><td><a href="sect15.html#push"><strong>push            </strong></a></td>
 </tr>
 
 <tr><td>     </td><td>    </td><td>  VAR:233</td><td>  9 </td><td> 1  </td><td>pull            (variable)</td>
-    <td><a href="sect15.html#pull"><strong>pull            </strong></a></td>
+    <td>XXX</td><td><a href="sect15.html#pull"><strong>pull            </strong></a></td>
 </tr>
 
 <tr><td>   * </td><td>    </td><td>        </td><td>     </td><td> 6  </td><td>pull            stack -> (result)</td>
-    <td><a href="sect15.html#pull"><strong>pull            </strong></a></td>
+    <td>XXX</td><td><a href="sect15.html#pull"><strong>pull            </strong></a></td>
 </tr>
 
 <tr><td>     </td><td>    </td><td>  VAR:234</td><td>  A </td><td> 3  </td><td>split_window    lines</td>
-    <td><a href="sect15.html#split_window"><strong>split_window    </strong></a></td>
+    <td>XXX</td><td><a href="sect15.html#split_window"><strong>split_window    </strong></a></td>
 </tr>
 
 <tr><td>     </td><td>    </td><td>  VAR:235</td><td>  B </td><td> 3  </td><td>set_window      window</td>
-    <td><a href="sect15.html#set_window"><strong>set_window      </strong></a></td>
+    <td>XXX</td><td><a href="sect15.html#set_window"><strong>set_window      </strong></a></td>
 </tr>
 
 <tr><td>   * </td><td>    </td><td>  VAR:236</td><td>  C </td><td> 4  </td><td>call_vs2        routine ...0 to 7 args... -> (result)</td>
-    <td><a href="sect15.html#call_vs2"><strong>call_vs2        </strong></a></td>
+    <td>XXX</td><td><a href="sect15.html#call_vs2"><strong>call_vs2        </strong></a></td>
 </tr>
 
 <tr><td>     </td><td>    </td><td>  VAR:237</td><td>  D </td><td> 4  </td><td>erase_window    window</td>
-    <td><a href="sect15.html#erase_window"><strong>erase_window    </strong></a></td>
+    <td>XXX</td><td><a href="sect15.html#erase_window"><strong>erase_window    </strong></a></td>
 </tr>
 
 <tr><td>     </td><td>    </td><td>  VAR:238</td><td>  E </td><td>4/- </td><td>erase_line      value</td>
-    <td><a href="sect15.html#erase_line"><strong>erase_line      </strong></a></td>
+    <td>XXX</td><td><a href="sect15.html#erase_line"><strong>erase_line      </strong></a></td>
 </tr>
 
 <tr><td>     </td><td>    </td><td>        </td><td>     </td><td> 6  </td><td>erase_line      pixels</td>
-    <td><a href="sect15.html#erase_line"><strong>erase_line      </strong></a></td>
+    <td>XXX</td><td><a href="sect15.html#erase_line"><strong>erase_line      </strong></a></td>
 </tr>
 
 <tr><td>     </td><td>    </td><td>  VAR:239</td><td>  F </td><td> 4  </td><td>set_cursor      line column</td>
-    <td><a href="sect15.html#set_cursor"><strong>set_cursor      </strong></a></td>
+    <td>XXX</td><td><a href="sect15.html#set_cursor"><strong>set_cursor      </strong></a></td>
 </tr>
 
 <tr><td>     </td><td>    </td><td>        </td><td>     </td><td> 6  </td><td>set_cursor      line column window</td>
-    <td><a href="sect15.html#set_cursor"><strong>set_cursor      </strong></a></td>
+    <td>XXX</td><td><a href="sect15.html#set_cursor"><strong>set_cursor      </strong></a></td>
 </tr>
 
 <tr><td>     </td><td>    </td><td>  VAR:240</td><td> 10 </td><td>4/6 </td><td>get_cursor      array</td>
-    <td><a href="sect15.html#get_cursor"><strong>get_cursor      </strong></a></td>
+    <td>XXX</td><td><a href="sect15.html#get_cursor"><strong>get_cursor      </strong></a></td>
 </tr>
 
 <tr><td>     </td><td>    </td><td>  VAR:241</td><td> 11 </td><td> 4  </td><td>set_text_style  style</td>
-    <td><a href="sect15.html#set_text_style"><strong>set_text_style  </strong></a></td>
+    <td>XXX</td><td><a href="sect15.html#set_text_style"><strong>set_text_style  </strong></a></td>
 </tr>
 
 <tr><td>     </td><td>    </td><td>  VAR:242</td><td> 12 </td><td> 4  </td><td>buffer_mode     flag</td>
-    <td><a href="sect15.html#buffer_mode"><strong>buffer_mode     </strong></a></td>
+    <td>XXX</td><td><a href="sect15.html#buffer_mode"><strong>buffer_mode     </strong></a></td>
 </tr>
 
 <tr><td>     </td><td>    </td><td>  VAR:243</td><td> 13 </td><td> 3  </td><td>output_stream   number</td>
-    <td><a href="sect15.html#output_stream"><strong>output_stream   </strong></a></td>
+    <td>XXX</td><td><a href="sect15.html#output_stream"><strong>output_stream   </strong></a></td>
 </tr>
 
 <tr><td>     </td><td>    </td><td>        </td><td>     </td><td> 5  </td><td>output_stream   number table</td>
-    <td><a href="sect15.html#output_stream"><strong>output_stream   </strong></a></td>
+    <td>XXX</td><td><a href="sect15.html#output_stream"><strong>output_stream   </strong></a></td>
 </tr>
 
 <tr><td>     </td><td>    </td><td>        </td><td>     </td><td> 6  </td><td>output_stream   number table width</td>
-    <td><a href="sect15.html#output_stream"><strong>output_stream   </strong></a></td>
+    <td>XXX</td><td><a href="sect15.html#output_stream"><strong>output_stream   </strong></a></td>
 </tr>
 
 <tr><td>     </td><td>    </td><td>  VAR:244</td><td> 14 </td><td> 3  </td><td>input_stream    number</td>
-    <td><a href="sect15.html#input_stream"><strong>input_stream    </strong></a></td>
+    <td>XXX</td><td><a href="sect15.html#input_stream"><strong>input_stream    </strong></a></td>
 </tr>
 
 <tr><td>     </td><td>    </td><td>  VAR:245</td><td> 15 </td><td>5/3 </td><td>sound_effect    number effect volume</td>
-    <td><a href="sect15.html#sound_effect"><strong>sound_effect    </strong></a></td>
+    <td>XXX</td><td><a href="sect15.html#sound_effect"><strong>sound_effect    </strong></a></td>
 </tr>
 
 <tr><td>     </td><td>    </td><td>         </td><td>    </td><td>5</td><td>sound_effect    number effect volume routine</td>
-    <td><a href="sect15.html#sound_effect"><strong>sound_effect    </strong></a></td>
+    <td>XXX</td><td><a href="sect15.html#sound_effect"><strong>sound_effect    </strong></a></td>
 </tr>
 
 <tr><td>   * </td><td>    </td><td>  VAR:246</td><td> 16 </td><td> 4  </td><td>read_char       1 time routine -> (result)</td>
-    <td><a href="sect15.html#read_char"><strong>read_char       </strong></a></td>
+    <td>XXX</td><td><a href="sect15.html#read_char"><strong>read_char       </strong></a></td>
 </tr>
 
 <tr><td>   * </td><td>   *</td><td>  VAR:247</td><td> 17 </td><td> 4  </td><td>scan_table      x table len form -> (result) ?(label)</td>
-    <td><a href="sect15.html#scan_table"><strong>scan_table      </strong></a></td>
+    <td>XXX</td><td><a href="sect15.html#scan_table"><strong>scan_table      </strong></a></td>
 </tr>
 
 <tr><td>   * </td><td>    </td><td>  VAR:248</td><td> 18 </td><td>5/6 </td><td>not             value -> (result)</td>
-    <td><a href="sect15.html#not"><strong>not             </strong></a></td>
+    <td>XXX</td><td><a href="sect15.html#not"><strong>not             </strong></a></td>
 </tr>
 
 <tr><td>     </td><td>    </td><td>  VAR:249</td><td> 19 </td><td> 5  </td><td>call_vn         routine ...up to 3 args...</td>
-    <td><a href="sect15.html#call_vn"><strong>call_vn         </strong></a></td>
+    <td>XXX</td><td><a href="sect15.html#call_vn"><strong>call_vn         </strong></a></td>
 </tr>
 
 <tr><td>     </td><td>    </td><td>  VAR:250</td><td> 1A </td><td> 5  </td><td>call_vn2        routine ...up to 7 args...</td>
-    <td><a href="sect15.html#call_vn2"><strong>call_vn2        </strong></a></td>
+    <td>XXX</td><td><a href="sect15.html#call_vn2"><strong>call_vn2        </strong></a></td>
 </tr>
 
 <tr><td>     </td><td>    </td><td>  VAR:251</td><td> 1B </td><td> 5  </td><td>tokenise        text parse dictionary flag</td>
-    <td><a href="sect15.html#tokenise"><strong>tokenise        </strong></a></td>
+    <td>XXX</td><td><a href="sect15.html#tokenise"><strong>tokenise        </strong></a></td>
 </tr>
 
 <tr><td>     </td><td>    </td><td>  VAR:252</td><td> 1C </td><td> 5  </td><td>encode_text     zscii-text length from coded-text</td>
-    <td><a href="sect15.html#encode_text"><strong>encode_text     </strong></a></td>
+    <td>XXX</td><td><a href="sect15.html#encode_text"><strong>encode_text     </strong></a></td>
 </tr>
 
 <tr><td>     </td><td>    </td><td>  VAR:253</td><td> 1D </td><td> 5  </td><td>copy_table      first second size</td>
-    <td><a href="sect15.html#copy_table"><strong>copy_table      </strong></a></td>
+    <td>XXX</td><td><a href="sect15.html#copy_table"><strong>copy_table      </strong></a></td>
 </tr>
 
 <tr><td>     </td><td>    </td><td>  VAR:254</td><td> 1E </td><td> 5  </td><td>print_table     zscii-text width height skip</td>
-    <td><a href="sect15.html#print_table"><strong>print_table     </strong></a></td>
+    <td>XXX</td><td><a href="sect15.html#print_table"><strong>print_table     </strong></a></td>
 </tr>
 
 <tr><td>     </td><td>   *</td><td>  VAR:255</td><td> 1F </td><td> 5  </td><td>check_arg_count argument-number ?(label)</td>
-    <td><a href="sect15.html#check_arg_count"><strong>check_arg_count </strong></a></td>
+    <td>XXX</td><td><a href="sect15.html#check_arg_count"><strong>check_arg_count </strong></a></td>
 </tr>
 
 </table>
@@ -508,130 +508,130 @@
 
 <caption><strong>Extended opcodes EXT</strong></caption>
 
-<tr><td>   St</td><td>  Br</td><td>  Opcode</td><td> Hex </td><td> V  </td><td>Inform name and syntax  </td><td>Link</td></tr>
+<tr><td>   St</td><td>  Br</td><td>  Opcode</td><td> Hex </td><td> V  </td><td>Inform name and syntax  </td><td>ZIL name</td><td>Link</td></tr>
 
 <tr><td>   * </td><td>    </td><td>  EXT:0 </td><td>   0 </td><td> 5  </td><td>save            table bytes name prompt -> (result)</td>
-    <td><a href="sect15.html#save"><strong>save            </strong></a></td>
+    <td>XXX</td><td><a href="sect15.html#save"><strong>save            </strong></a></td>
 </tr>
 
 <tr><td>   * </td><td>    </td><td>  EXT:1 </td><td>   1 </td><td> 5  </td><td>restore         table bytes name prompt -> (result)</td>
-    <td><a href="sect15.html#restore"><strong>restore         </strong></a></td>
+    <td>XXX</td><td><a href="sect15.html#restore"><strong>restore         </strong></a></td>
 </tr>
 
 <tr><td>   * </td><td>    </td><td>  EXT:2 </td><td>   2 </td><td> 5  </td><td>log_shift       number places -> (result)</td>
-    <td><a href="sect15.html#log_shift"><strong>log_shift       </strong></a></td>
+    <td>XXX</td><td><a href="sect15.html#log_shift"><strong>log_shift       </strong></a></td>
 </tr>
 
 <tr><td>   * </td><td>    </td><td>  EXT:3 </td><td>   3 </td><td>5/- </td><td>art_shift       number places -> (result)</td>
-    <td><a href="sect15.html#art_shift"><strong>art_shift       </strong></a></td>
+    <td>XXX</td><td><a href="sect15.html#art_shift"><strong>art_shift       </strong></a></td>
 </tr>
 
 <tr><td>   * </td><td>    </td><td>  EXT:4 </td><td>   4 </td><td> 5  </td><td>set_font        font -> (result)</td>
-    <td><a href="sect15.html#set_font"><strong>set_font        </strong></a></td>
+    <td>XXX</td><td><a href="sect15.html#set_font"><strong>set_font        </strong></a></td>
 </tr>
 
 <tr><td>   * </td><td>    </td><td></td><td>     </td><td> 6/-  </td><td>set_font        font window -> (result)</td>
-    <td><a href="sect15.html#set_font"><strong>set_font        </strong></a></td>
+    <td>XXX</td><td><a href="sect15.html#set_font"><strong>set_font        </strong></a></td>
 </tr>
 
 
 <tr><td>     </td><td>    </td><td>  EXT:5 </td><td>   5 </td><td> 6  </td><td>draw_picture    picture-number y x</td>
-    <td><a href="sect15.html#draw_picture"><strong>draw_picture    </strong></a></td>
+    <td>XXX</td><td><a href="sect15.html#draw_picture"><strong>draw_picture    </strong></a></td>
 </tr>
 
 <tr><td>     </td><td>   *</td><td>  EXT:6 </td><td>   6 </td><td> 6  </td><td>picture_data    picture-number array ?(label)</td>
-    <td><a href="sect15.html#picture_data"><strong>picture_data    </strong></a></td>
+    <td>XXX</td><td><a href="sect15.html#picture_data"><strong>picture_data    </strong></a></td>
 </tr>
 
 <tr><td>     </td><td>    </td><td>  EXT:7 </td><td>   7 </td><td> 6  </td><td>erase_picture   picture-number y x</td>
-    <td><a href="sect15.html#erase_picture"><strong>erase_picture   </strong></a></td>
+    <td>XXX</td><td><a href="sect15.html#erase_picture"><strong>erase_picture   </strong></a></td>
 </tr>
 
 <tr><td>     </td><td>    </td><td>  EXT:8 </td><td>   8 </td><td> 6  </td><td>set_margins     left right window</td>
-    <td><a href="sect15.html#set_margins"><strong>set_margins     </strong></a></td>
+    <td>XXX</td><td><a href="sect15.html#set_margins"><strong>set_margins     </strong></a></td>
 </tr>
 
 <tr><td>   * </td><td>    </td><td>  EXT:9 </td><td>   9 </td><td> 5  </td><td>save_undo       -> (result)</td>
-    <td><a href="sect15.html#save_undo"><strong>save_undo       </strong></a></td>
+    <td>XXX</td><td><a href="sect15.html#save_undo"><strong>save_undo       </strong></a></td>
 </tr>
 
 <tr><td>   * </td><td>    </td><td>  EXT:10</td><td>   A </td><td> 5  </td><td>restore_undo    -> (result)</td>
-    <td><a href="sect15.html#restore_undo"><strong>restore_undo    </strong></a></td>
+    <td>XXX</td><td><a href="sect15.html#restore_undo"><strong>restore_undo    </strong></a></td>
 </tr>
 
 <tr><td>     </td><td>    </td><td>  EXT:11</td><td>   B </td><td>5/* </td><td>print_unicode   char-number</td>
-    <td><a href="sect15.html#print_unicode"><strong>print_unicode   </strong></a></td>
+    <td>XXX</td><td><a href="sect15.html#print_unicode"><strong>print_unicode   </strong></a></td>
 </tr>
 
 <tr><td>   * </td><td>    </td><td>  EXT:12</td><td>   C </td><td>5/* </td><td>check_unicode   char-number -> (result)</td>
-    <td><a href="sect15.html#check_unicode"><strong>check_unicode   </strong></a></td>
+    <td>XXX</td><td><a href="sect15.html#check_unicode"><strong>check_unicode   </strong></a></td>
 </tr>
 
 <tr><td>     </td><td>    </td><td>  EXT:13</td><td>  D </td><td>5/* </td><td>set_true_colour foreground background</td>
-    <td><a href="sect15.html#set_true_colour"><strong>set_true_colour   </strong></a></td>
+    <td>XXX</td><td><a href="sect15.html#set_true_colour"><strong>set_true_colour   </strong></a></td>
 </tr>
 
 <tr><td>     </td><td>    </td><td>  </td><td>   </td><td>6/* </td><td>set_true_colour foreground background window</td>
-    <td><a href="sect15.html#set_true_colour"><strong>set_true_colour   </strong></a></td>
+    <td>XXX</td><td><a href="sect15.html#set_true_colour"><strong>set_true_colour   </strong></a></td>
 </tr>
 
-<tr><td>     </td><td>    </td><td>  -------</td><td>  E </td><td> ---</td><td>---</td><td></td></tr>
-<tr><td>     </td><td>    </td><td>  -------</td><td>  F </td><td> ---</td><td>---</td><td></td></tr>
+<tr><td>     </td><td>    </td><td>  -------</td><td>  E </td><td> ---</td><td>---</td><td></td><td></td></tr>
+<tr><td>     </td><td>    </td><td>  -------</td><td>  F </td><td> ---</td><td>---</td><td></td><td></td></tr>
 
 <tr><td>     </td><td>    </td><td>  EXT:16</td><td>  10 </td><td> 6  </td><td>move_window     window y x</td>
-    <td><a href="sect15.html#move_window"><strong>move_window     </strong></a></td>
+    <td>XXX</td><td><a href="sect15.html#move_window"><strong>move_window     </strong></a></td>
 </tr>
 
 <tr><td>     </td><td>    </td><td>  EXT:17</td><td>  11 </td><td> 6  </td><td>window_size     window y x</td>
-    <td><a href="sect15.html#window_size"><strong>window_size     </strong></a></td>
+    <td>XXX</td><td><a href="sect15.html#window_size"><strong>window_size     </strong></a></td>
 </tr>
 
 <tr><td>     </td><td>    </td><td>  EXT:18</td><td>  12 </td><td> 6  </td><td>window_style    window flags operation</td>
-    <td><a href="sect15.html#window_style"><strong>window_style    </strong></a></td>
+    <td>XXX</td><td><a href="sect15.html#window_style"><strong>window_style    </strong></a></td>
 </tr>
 
 <tr><td>   * </td><td>    </td><td>  EXT:19</td><td>  13 </td><td> 6  </td><td>get_wind_prop   window property-number -> (result)</td>
-    <td><a href="sect15.html#get_wind_prop"><strong>get_wind_prop   </strong></a></td>
+    <td>XXX</td><td><a href="sect15.html#get_wind_prop"><strong>get_wind_prop   </strong></a></td>
 </tr>
 
 <tr><td>     </td><td>    </td><td>  EXT:20</td><td>  14 </td><td> 6  </td><td>scroll_window   window pixels</td>
-    <td><a href="sect15.html#scroll_window"><strong>scroll_window   </strong></a></td>
+    <td>XXX</td><td><a href="sect15.html#scroll_window"><strong>scroll_window   </strong></a></td>
 </tr>
 
 <tr><td>     </td><td>    </td><td>  EXT:21</td><td>  15 </td><td> 6  </td><td>pop_stack       items stack</td>
-    <td><a href="sect15.html#pop_stack"><strong>pop_stack       </strong></a></td>
+    <td>XXX</td><td><a href="sect15.html#pop_stack"><strong>pop_stack       </strong></a></td>
 </tr>
 
 <tr><td>     </td><td>    </td><td>  EXT:22</td><td>  16 </td><td> 6  </td><td>read_mouse      array</td>
-    <td><a href="sect15.html#read_mouse"><strong>read_mouse      </strong></a></td>
+    <td>XXX</td><td><a href="sect15.html#read_mouse"><strong>read_mouse      </strong></a></td>
 </tr>
 
 <tr><td>     </td><td>    </td><td>  EXT:23</td><td>  17 </td><td> 6  </td><td>mouse_window    window</td>
-    <td><a href="sect15.html#mouse_window"><strong>mouse_window    </strong></a></td>
+    <td>XXX</td><td><a href="sect15.html#mouse_window"><strong>mouse_window    </strong></a></td>
 </tr>
 
 <tr><td>     </td><td>   *</td><td>  EXT:24</td><td>  18 </td><td> 6  </td><td>push_stack      value stack ?(label)</td>
-    <td><a href="sect15.html#push_stack"><strong>push_stack      </strong></a></td>
+    <td>XXX</td><td><a href="sect15.html#push_stack"><strong>push_stack      </strong></a></td>
 </tr>
 
 <tr><td>     </td><td>    </td><td>  EXT:25</td><td>  19 </td><td> 6  </td><td>put_wind_prop   window property-number value</td>
-    <td><a href="sect15.html#put_wind_prop"><strong>put_wind_prop   </strong></a></td>
+    <td>XXX</td><td><a href="sect15.html#put_wind_prop"><strong>put_wind_prop   </strong></a></td>
 </tr>
 
 <tr><td>     </td><td>    </td><td>  EXT:26</td><td>  1A </td><td> 6  </td><td>print_form      formatted-table</td>
-    <td><a href="sect15.html#print_form"><strong>print_form      </strong></a></td>
+    <td>XXX</td><td><a href="sect15.html#print_form"><strong>print_form      </strong></a></td>
 </tr>
 
 <tr><td>     </td><td>   *</td><td>  EXT:27</td><td>  1B </td><td> 6  </td><td>make_menu       number table ?(label)</td>
-    <td><a href="sect15.html#make_menu"><strong>make_menu       </strong></a></td>
+    <td>XXX</td><td><a href="sect15.html#make_menu"><strong>make_menu       </strong></a></td>
 </tr>
 
 <tr><td>     </td><td>    </td><td>  EXT:28</td><td>  1C </td><td> 6  </td><td>picture_table   table</td>
-    <td><a href="sect15.html#picture_table"><strong>picture_table   </strong></a></td>
+    <td>XXX</td><td><a href="sect15.html#picture_table"><strong>picture_table   </strong></a></td>
 </tr>
 
 <tr><td>   * </td><td>    </td><td>  EXT:29</td><td>  1D </td><td> 6/*</td><td>buffer_screen mode -> (result)</td>
-    <td><a href="sect15.html#buffer_screen"><strong>buffer_screen   </strong></a></td>
+    <td>XXX</td><td><a href="sect15.html#buffer_screen"><strong>buffer_screen   </strong></a></td>
 </tr>
 
 </table>

--- a/sect14.html
+++ b/sect14.html
@@ -228,7 +228,7 @@
 </tr>
 
 <tr><td>   * </td><td>    </td><td>  1OP:143</td><td>  F </td><td>1/4 </td><td>not             value -> (result)</td>
-    <td></td><td><a href="sect15.html#not"><strong>not             </strong></a></td>
+    <td>BCOM</td><td><a href="sect15.html#not"><strong>not             </strong></a></td>
 </tr>
 
 <tr><td>     </td><td>    </td><td>        </td><td>     </td><td> 5  </td><td>call_1n         routine</td>
@@ -266,21 +266,21 @@
 <tr><td>     </td><td>    </td><td>  0OP:180</td><td>  4 </td><td>1/- </td><td>nop</td><td>NOOP</td><td><a href="sect15.html#nop"><strong>nop</strong></a></td></tr>
 
 <tr><td>     </td><td>  * </td><td>  0OP:181</td><td>  5 </td><td> 1  </td>
-    <td>save            ?(label)</td><td></td><td><a href="sect15.html#save"><strong>save            </strong></a></td>
+    <td>save            ?(label)</td><td>SAVE</td><td><a href="sect15.html#save"><strong>save            </strong></a></td>
 </tr>
 
 <tr><td>   * </td><td>    </td><td>        </td><td>     </td><td> 4  </td><td>save            -> (result)</td>
-    <td></td><td><a href="sect15.html#save"><strong>save            </strong></a></td>
+    <td>SAVE</td><td><a href="sect15.html#save"><strong>save            </strong></a></td>
 </tr>
 
 <tr><td>     </td><td>    </td><td>        </td><td>     </td><td> 5  </td><td>[illegal]</td><td></td><td></td></tr>
 
 <tr><td>     </td><td>  * </td><td>  0OP:182</td><td>  6 </td><td> 1  </td><td>restore         ?(label)</td>
-    <td></td><td><a href="sect15.html#restore"><strong>restore         </strong></a></td>
+    <td>RESTORE</td><td><a href="sect15.html#restore"><strong>restore         </strong></a></td>
 </tr>
 
 <tr><td>   * </td><td>    </td><td>        </td><td>     </td><td> 4  </td><td>restore         -> (result)</td>
-    <td></td><td><a href="sect15.html#restore"><strong>restore         </strong></a></td>
+    <td>RESTORE</td><td><a href="sect15.html#restore"><strong>restore         </strong></a></td>
 </tr>
 
 <tr><td>     </td><td>    </td><td>        </td><td>     </td><td> 5  </td><td>[illegal]</td><td></td><td></td></tr>

--- a/sect14.html
+++ b/sect14.html
@@ -338,167 +338,167 @@
 <tr><td>   St</td><td>  Br</td><td>  Opcode</td><td> Hex </td><td> V  </td><td>Inform name and syntax  </td><td>ZIL name</td><td>Link</td></tr>
 
 <tr><td>   * </td><td>    </td><td>  VAR:224</td><td>  0 </td><td> 1  </td><td>call            routine ...0 to 3 args... -> (result)</td>
-    <td>XXX</td><td><a href="sect15.html#call"><strong>call            </strong></a></td>
+    <td>CALL</td><td><a href="sect15.html#call"><strong>call            </strong></a></td>
 </tr>
 
 <tr><td>   * </td><td>    </td><td>        </td><td>     </td><td> 4  </td><td>call_vs         routine ...0 to 3 args... -> (result)</td>
-    <td>XXX</td><td><a href="sect15.html#call_vs"><strong>call_vs         </strong></a></td>
+    <td>CALL</td><td><a href="sect15.html#call_vs"><strong>call_vs         </strong></a></td>
 </tr>
 
 <tr><td>     </td><td>    </td><td>  VAR:225</td><td>  1 </td><td>    </td><td>storew          array word-index value</td>
-    <td>XXX</td><td><a href="sect15.html#storew"><strong>storew          </strong></a></td>
+    <td>PUT</td><td><a href="sect15.html#storew"><strong>storew          </strong></a></td>
 </tr>
 
 <tr><td>     </td><td>    </td><td>  VAR:226</td><td>  2 </td><td>    </td><td>storeb          array byte-index value</td>
-    <td>XXX</td><td><a href="sect15.html#storeb"><strong>storeb          </strong></a></td>
+    <td>PUTB</td><td><a href="sect15.html#storeb"><strong>storeb          </strong></a></td>
 </tr>
 
 <tr><td>     </td><td>    </td><td>  VAR:227</td><td>  3 </td><td>    </td><td>put_prop        object property value</td>
-    <td>XXX</td><td><a href="sect15.html#put_prop"><strong>put_prop        </strong></a></td>
+    <td>PUTP</td><td><a href="sect15.html#put_prop"><strong>put_prop        </strong></a></td>
 </tr>
 
 <tr><td>     </td><td>    </td><td>  VAR:228</td><td>  4 </td><td> 1  </td><td>sread           text parse</td>
-    <td>XXX</td><td><a href="sect15.html#sread"><strong>sread           </strong></a></td>
+    <td>READ</td><td><a href="sect15.html#sread"><strong>sread           </strong></a></td>
 </tr>
 
 <tr><td>     </td><td>    </td><td>        </td><td>     </td><td> 4  </td><td>sread           text parse time routine</td>
-    <td>XXX</td><td><a href="sect15.html#sread"><strong>sread           </strong></a></td>
+    <td>READ</td><td><a href="sect15.html#sread"><strong>sread           </strong></a></td>
 </tr>
 
 <tr><td>   * </td><td>    </td><td>        </td><td>     </td><td> 5  </td><td>aread           text parse time routine -> (result)</td>
-    <td>XXX</td><td><a href="sect15.html#aread"><strong>aread           </strong></a></td>
+    <td>READ</td><td><a href="sect15.html#aread"><strong>aread           </strong></a></td>
 </tr>
 
 <tr><td>     </td><td>    </td><td>  VAR:229</td><td>  5 </td><td>    </td><td>print_char      output-character-code</td>
-    <td>XXX</td><td><a href="sect15.html#print_char"><strong>print_char      </strong></a></td>
+    <td>PRINTC</td><td><a href="sect15.html#print_char"><strong>print_char      </strong></a></td>
 </tr>
 
 <tr><td>     </td><td>    </td><td>  VAR:230</td><td>  6 </td><td>    </td><td>print_num       value</td>
-    <td>XXX</td><td><a href="sect15.html#print_num"><strong>print_num       </strong></a></td>
+    <td>PRINTN</td><td><a href="sect15.html#print_num"><strong>print_num       </strong></a></td>
 </tr>
 
 <tr><td>   * </td><td>    </td><td>  VAR:231</td><td>  7 </td><td>    </td><td>random          range -> (result)</td>
-    <td>XXX</td><td><a href="sect15.html#random"><strong>random          </strong></a></td>
+    <td>RANDOM</td><td><a href="sect15.html#random"><strong>random          </strong></a></td>
 </tr>
 
 <tr><td>     </td><td>    </td><td>  VAR:232</td><td>  8 </td><td>    </td><td>push            value</td>
-    <td>XXX</td><td><a href="sect15.html#push"><strong>push            </strong></a></td>
+    <td>PUSH</td><td><a href="sect15.html#push"><strong>push            </strong></a></td>
 </tr>
 
 <tr><td>     </td><td>    </td><td>  VAR:233</td><td>  9 </td><td> 1  </td><td>pull            (variable)</td>
-    <td>XXX</td><td><a href="sect15.html#pull"><strong>pull            </strong></a></td>
+    <td>POP</td><td><a href="sect15.html#pull"><strong>pull            </strong></a></td>
 </tr>
 
 <tr><td>   * </td><td>    </td><td>        </td><td>     </td><td> 6  </td><td>pull            stack -> (result)</td>
-    <td>XXX</td><td><a href="sect15.html#pull"><strong>pull            </strong></a></td>
+    <td>POP</td><td><a href="sect15.html#pull"><strong>pull            </strong></a></td>
 </tr>
 
 <tr><td>     </td><td>    </td><td>  VAR:234</td><td>  A </td><td> 3  </td><td>split_window    lines</td>
-    <td>XXX</td><td><a href="sect15.html#split_window"><strong>split_window    </strong></a></td>
+    <td>SPLIT</td><td><a href="sect15.html#split_window"><strong>split_window    </strong></a></td>
 </tr>
 
 <tr><td>     </td><td>    </td><td>  VAR:235</td><td>  B </td><td> 3  </td><td>set_window      window</td>
-    <td>XXX</td><td><a href="sect15.html#set_window"><strong>set_window      </strong></a></td>
+    <td>SCREEN</td><td><a href="sect15.html#set_window"><strong>set_window      </strong></a></td>
 </tr>
 
 <tr><td>   * </td><td>    </td><td>  VAR:236</td><td>  C </td><td> 4  </td><td>call_vs2        routine ...0 to 7 args... -> (result)</td>
-    <td>XXX</td><td><a href="sect15.html#call_vs2"><strong>call_vs2        </strong></a></td>
+    <td>XCALL</td><td><a href="sect15.html#call_vs2"><strong>call_vs2        </strong></a></td>
 </tr>
 
 <tr><td>     </td><td>    </td><td>  VAR:237</td><td>  D </td><td> 4  </td><td>erase_window    window</td>
-    <td>XXX</td><td><a href="sect15.html#erase_window"><strong>erase_window    </strong></a></td>
+    <td>CLEAR</td><td><a href="sect15.html#erase_window"><strong>erase_window    </strong></a></td>
 </tr>
 
 <tr><td>     </td><td>    </td><td>  VAR:238</td><td>  E </td><td>4/- </td><td>erase_line      value</td>
-    <td>XXX</td><td><a href="sect15.html#erase_line"><strong>erase_line      </strong></a></td>
+    <td>ERASE</td><td><a href="sect15.html#erase_line"><strong>erase_line      </strong></a></td>
 </tr>
 
 <tr><td>     </td><td>    </td><td>        </td><td>     </td><td> 6  </td><td>erase_line      pixels</td>
-    <td>XXX</td><td><a href="sect15.html#erase_line"><strong>erase_line      </strong></a></td>
+    <td>ERASE</td><td><a href="sect15.html#erase_line"><strong>erase_line      </strong></a></td>
 </tr>
 
 <tr><td>     </td><td>    </td><td>  VAR:239</td><td>  F </td><td> 4  </td><td>set_cursor      line column</td>
-    <td>XXX</td><td><a href="sect15.html#set_cursor"><strong>set_cursor      </strong></a></td>
+    <td>CURSET</td><td><a href="sect15.html#set_cursor"><strong>set_cursor      </strong></a></td>
 </tr>
 
 <tr><td>     </td><td>    </td><td>        </td><td>     </td><td> 6  </td><td>set_cursor      line column window</td>
-    <td>XXX</td><td><a href="sect15.html#set_cursor"><strong>set_cursor      </strong></a></td>
+    <td>CURSET</td><td><a href="sect15.html#set_cursor"><strong>set_cursor      </strong></a></td>
 </tr>
 
 <tr><td>     </td><td>    </td><td>  VAR:240</td><td> 10 </td><td>4/6 </td><td>get_cursor      array</td>
-    <td>XXX</td><td><a href="sect15.html#get_cursor"><strong>get_cursor      </strong></a></td>
+    <td>CURGET</td><td><a href="sect15.html#get_cursor"><strong>get_cursor      </strong></a></td>
 </tr>
 
 <tr><td>     </td><td>    </td><td>  VAR:241</td><td> 11 </td><td> 4  </td><td>set_text_style  style</td>
-    <td>XXX</td><td><a href="sect15.html#set_text_style"><strong>set_text_style  </strong></a></td>
+    <td>HLIGHT</td><td><a href="sect15.html#set_text_style"><strong>set_text_style  </strong></a></td>
 </tr>
 
 <tr><td>     </td><td>    </td><td>  VAR:242</td><td> 12 </td><td> 4  </td><td>buffer_mode     flag</td>
-    <td>XXX</td><td><a href="sect15.html#buffer_mode"><strong>buffer_mode     </strong></a></td>
+    <td>BUFOUT</td><td><a href="sect15.html#buffer_mode"><strong>buffer_mode     </strong></a></td>
 </tr>
 
 <tr><td>     </td><td>    </td><td>  VAR:243</td><td> 13 </td><td> 3  </td><td>output_stream   number</td>
-    <td>XXX</td><td><a href="sect15.html#output_stream"><strong>output_stream   </strong></a></td>
+    <td>DIROUT</td><td><a href="sect15.html#output_stream"><strong>output_stream   </strong></a></td>
 </tr>
 
 <tr><td>     </td><td>    </td><td>        </td><td>     </td><td> 5  </td><td>output_stream   number table</td>
-    <td>XXX</td><td><a href="sect15.html#output_stream"><strong>output_stream   </strong></a></td>
+    <td>DIROUT</td><td><a href="sect15.html#output_stream"><strong>output_stream   </strong></a></td>
 </tr>
 
 <tr><td>     </td><td>    </td><td>        </td><td>     </td><td> 6  </td><td>output_stream   number table width</td>
-    <td>XXX</td><td><a href="sect15.html#output_stream"><strong>output_stream   </strong></a></td>
+    <td>DIROUT</td><td><a href="sect15.html#output_stream"><strong>output_stream   </strong></a></td>
 </tr>
 
 <tr><td>     </td><td>    </td><td>  VAR:244</td><td> 14 </td><td> 3  </td><td>input_stream    number</td>
-    <td>XXX</td><td><a href="sect15.html#input_stream"><strong>input_stream    </strong></a></td>
+    <td>DIRIN</td><td><a href="sect15.html#input_stream"><strong>input_stream    </strong></a></td>
 </tr>
 
 <tr><td>     </td><td>    </td><td>  VAR:245</td><td> 15 </td><td>5/3 </td><td>sound_effect    number effect volume</td>
-    <td>XXX</td><td><a href="sect15.html#sound_effect"><strong>sound_effect    </strong></a></td>
+    <td>SOUND</td><td><a href="sect15.html#sound_effect"><strong>sound_effect    </strong></a></td>
 </tr>
 
 <tr><td>     </td><td>    </td><td>         </td><td>    </td><td>5</td><td>sound_effect    number effect volume routine</td>
-    <td>XXX</td><td><a href="sect15.html#sound_effect"><strong>sound_effect    </strong></a></td>
+    <td>SOUND</td><td><a href="sect15.html#sound_effect"><strong>sound_effect    </strong></a></td>
 </tr>
 
 <tr><td>   * </td><td>    </td><td>  VAR:246</td><td> 16 </td><td> 4  </td><td>read_char       1 time routine -> (result)</td>
-    <td>XXX</td><td><a href="sect15.html#read_char"><strong>read_char       </strong></a></td>
+    <td>INPUT</td><td><a href="sect15.html#read_char"><strong>read_char       </strong></a></td>
 </tr>
 
 <tr><td>   * </td><td>   *</td><td>  VAR:247</td><td> 17 </td><td> 4  </td><td>scan_table      x table len form -> (result) ?(label)</td>
-    <td>XXX</td><td><a href="sect15.html#scan_table"><strong>scan_table      </strong></a></td>
+    <td>INTBL?</td><td><a href="sect15.html#scan_table"><strong>scan_table      </strong></a></td>
 </tr>
 
 <tr><td>   * </td><td>    </td><td>  VAR:248</td><td> 18 </td><td>5/6 </td><td>not             value -> (result)</td>
-    <td>XXX</td><td><a href="sect15.html#not"><strong>not             </strong></a></td>
+    <td>BCOM</td><td><a href="sect15.html#not"><strong>not             </strong></a></td>
 </tr>
 
 <tr><td>     </td><td>    </td><td>  VAR:249</td><td> 19 </td><td> 5  </td><td>call_vn         routine ...up to 3 args...</td>
-    <td>XXX</td><td><a href="sect15.html#call_vn"><strong>call_vn         </strong></a></td>
+    <td>ICALL</td><td><a href="sect15.html#call_vn"><strong>call_vn         </strong></a></td>
 </tr>
 
 <tr><td>     </td><td>    </td><td>  VAR:250</td><td> 1A </td><td> 5  </td><td>call_vn2        routine ...up to 7 args...</td>
-    <td>XXX</td><td><a href="sect15.html#call_vn2"><strong>call_vn2        </strong></a></td>
+    <td>IXCALL</td><td><a href="sect15.html#call_vn2"><strong>call_vn2        </strong></a></td>
 </tr>
 
 <tr><td>     </td><td>    </td><td>  VAR:251</td><td> 1B </td><td> 5  </td><td>tokenise        text parse dictionary flag</td>
-    <td>XXX</td><td><a href="sect15.html#tokenise"><strong>tokenise        </strong></a></td>
+    <td>LEX</td><td><a href="sect15.html#tokenise"><strong>tokenise        </strong></a></td>
 </tr>
 
 <tr><td>     </td><td>    </td><td>  VAR:252</td><td> 1C </td><td> 5  </td><td>encode_text     zscii-text length from coded-text</td>
-    <td>XXX</td><td><a href="sect15.html#encode_text"><strong>encode_text     </strong></a></td>
+    <td>ZWSTR</td><td><a href="sect15.html#encode_text"><strong>encode_text     </strong></a></td>
 </tr>
 
 <tr><td>     </td><td>    </td><td>  VAR:253</td><td> 1D </td><td> 5  </td><td>copy_table      first second size</td>
-    <td>XXX</td><td><a href="sect15.html#copy_table"><strong>copy_table      </strong></a></td>
+    <td>COPYT</td><td><a href="sect15.html#copy_table"><strong>copy_table      </strong></a></td>
 </tr>
 
 <tr><td>     </td><td>    </td><td>  VAR:254</td><td> 1E </td><td> 5  </td><td>print_table     zscii-text width height skip</td>
-    <td>XXX</td><td><a href="sect15.html#print_table"><strong>print_table     </strong></a></td>
+    <td>PRINTT</td><td><a href="sect15.html#print_table"><strong>print_table     </strong></a></td>
 </tr>
 
 <tr><td>     </td><td>   *</td><td>  VAR:255</td><td> 1F </td><td> 5  </td><td>check_arg_count argument-number ?(label)</td>
-    <td>XXX</td><td><a href="sect15.html#check_arg_count"><strong>check_arg_count </strong></a></td>
+    <td>ASSIGNED?</td><td><a href="sect15.html#check_arg_count"><strong>check_arg_count </strong></a></td>
 </tr>
 
 </table>

--- a/sect14.html
+++ b/sect14.html
@@ -168,71 +168,71 @@
 <tr><td>   St</td><td>  Br</td><td>  Opcode</td><td> Hex </td><td> V  </td><td>Inform name and syntax  </td><td>ZIL name</td><td>Link</td></tr>
 
 <tr><td>     </td><td>  * </td><td>  1OP:128</td><td>  0 </td><td>    </td><td>jz              a ?(label)</td>
-    <td>XXX</td><td><a href="sect15.html#jz"><strong>jz              </strong></a></td>
+    <td>ZERO?</td><td><a href="sect15.html#jz"><strong>jz              </strong></a></td>
 </tr>
 
 <tr><td>   * </td><td>  * </td><td>  1OP:129</td><td>  1 </td><td>    </td><td>get_sibling     object -> (result) ?(label)</td>
-    <td>XXX</td><td><a href="sect15.html#get_sibling"><strong>get_sibling     </strong></a></td>
+    <td>NEXT?</td><td><a href="sect15.html#get_sibling"><strong>get_sibling     </strong></a></td>
 </tr>
 
 <tr><td>   * </td><td>  * </td><td>  1OP:130</td><td>  2 </td><td>    </td><td>get_child       object -> (result) ?(label)</td>
-    <td>XXX</td><td><a href="sect15.html#get_child"><strong>get_child       </strong></a></td>
+    <td>FIRST?</td><td><a href="sect15.html#get_child"><strong>get_child       </strong></a></td>
 </tr>
 
 <tr><td>   * </td><td>    </td><td>  1OP:131</td><td>  3 </td><td>    </td><td>get_parent      object -> (result)</td>
-    <td>XXX</td><td><a href="sect15.html#get_parent"><strong>get_parent      </strong></a></td>
+    <td>LOC</td><td><a href="sect15.html#get_parent"><strong>get_parent      </strong></a></td>
 </tr>
 
 <tr><td>   * </td><td>    </td><td>  1OP:132</td><td>  4 </td><td>    </td><td>get_prop_len    property-address -> (result)</td>
-    <td>XXX</td><td><a href="sect15.html#get_prop_len"><strong>get_prop_len    </strong></a></td>
+    <td>PTSIZE</td><td><a href="sect15.html#get_prop_len"><strong>get_prop_len    </strong></a></td>
 </tr>
 
 <tr><td>     </td><td>    </td><td>  1OP:133</td><td>  5 </td><td>    </td><td>inc             (variable)</td>
-    <td>XXX</td><td><a href="sect15.html#inc"><strong>inc             </strong></a></td>
+    <td>INC</td><td><a href="sect15.html#inc"><strong>inc             </strong></a></td>
 </tr>
 
 <tr><td>     </td><td>    </td><td>  1OP:134</td><td>  6 </td><td>    </td><td>dec             (variable)</td>
-    <td>XXX</td><td><a href="sect15.html#dec"><strong>dec             </strong></a></td>
+    <td>DEC</td><td><a href="sect15.html#dec"><strong>dec             </strong></a></td>
 </tr>
 
 <tr><td>     </td><td>    </td><td>  1OP:135</td><td>  7 </td><td>    </td><td>print_addr      byte-address-of-string</td>
-    <td>XXX</td><td><a href="sect15.html#print_addr"><strong>print_addr      </strong></a></td>
+    <td>PRINTB</td><td><a href="sect15.html#print_addr"><strong>print_addr      </strong></a></td>
 </tr>
 
 <tr><td>   * </td><td>    </td><td>  1OP:136</td><td>  8 </td><td> 4  </td><td>call_1s         routine -> (result)</td>
-    <td>XXX</td><td><a href="sect15.html#call_1s"><strong>call_1s         </strong></a></td>
+    <td>CALL1</td><td><a href="sect15.html#call_1s"><strong>call_1s         </strong></a></td>
 </tr>
 
 <tr><td>     </td><td>    </td><td>  1OP:137</td><td>  9 </td><td>    </td><td>remove_obj      object</td>
-    <td>XXX</td><td><a href="sect15.html#remove_obj"><strong>remove_obj      </strong></a></td>
+    <td>REMOVE</td><td><a href="sect15.html#remove_obj"><strong>remove_obj      </strong></a></td>
 </tr>
 
 <tr><td>     </td><td>    </td><td>  1OP:138</td><td>  A </td><td>    </td><td>print_obj       object</td>
-    <td>XXX</td><td><a href="sect15.html#print_obj"><strong>print_obj       </strong></a></td>
+    <td>PRINTD</td><td><a href="sect15.html#print_obj"><strong>print_obj       </strong></a></td>
 </tr>
 
 <tr><td>     </td><td>    </td><td>  1OP:139</td><td>  B </td><td>    </td><td>ret             value</td>
-    <td>XXX</td><td><a href="sect15.html#ret"><strong>ret             </strong></a></td>
+    <td>RETURN</td><td><a href="sect15.html#ret"><strong>ret             </strong></a></td>
 </tr>
 
 <tr><td>     </td><td>    </td><td>  1OP:140</td><td>  C </td><td>    </td><td>jump            ?(label)</td>
-    <td>XXX</td><td><a href="sect15.html#jump"><strong>jump            </strong></a></td>
+    <td>JUMP</td><td><a href="sect15.html#jump"><strong>jump            </strong></a></td>
 </tr>
 
 <tr><td>     </td><td>    </td><td>  1OP:141</td><td>  D </td><td>    </td><td>print_paddr     packed-address-of-string</td>
-    <td>XXX</td><td><a href="sect15.html#print_paddr"><strong>print_paddr     </strong></a></td>
+    <td>PRINT</td><td><a href="sect15.html#print_paddr"><strong>print_paddr     </strong></a></td>
 </tr>
 
 <tr><td>   * </td><td>    </td><td>  1OP:142</td><td>  E </td><td>    </td><td>load            (variable) -> (result)</td>
-    <td>XXX</td><td><a href="sect15.html#load"><strong>load            </strong></a></td>
+    <td>VALUE</td><td><a href="sect15.html#load"><strong>load            </strong></a></td>
 </tr>
 
 <tr><td>   * </td><td>    </td><td>  1OP:143</td><td>  F </td><td>1/4 </td><td>not             value -> (result)</td>
-    <td>XXX</td><td><a href="sect15.html#not"><strong>not             </strong></a></td>
+    <td></td><td><a href="sect15.html#not"><strong>not             </strong></a></td>
 </tr>
 
 <tr><td>     </td><td>    </td><td>        </td><td>     </td><td> 5  </td><td>call_1n         routine</td>
-    <td>XXX</td><td><a href="sect15.html#call_1n"><strong>call_1n         </strong></a></td>
+    <td>ICALL1</td><td><a href="sect15.html#call_1n"><strong>call_1n         </strong></a></td>
 </tr>
 
 <tr><td colspan="8" class="note">Opcode numbers 144 to 175: other forms of 1OP with different types.</td></tr>

--- a/sect14.html
+++ b/sect14.html
@@ -248,83 +248,83 @@
 <tr><td>   St</td><td>  Br</td><td>  Opcode</td><td> Hex </td><td> V  </td><td>Inform name and syntax  </td><td>ZIL name</td><td>Link</td></tr>
 
 <tr><td>     </td><td>    </td><td>  0OP:176</td><td>  0 </td><td>    </td><td>rtrue</td>
-    <td>XXX</td><td><a href="sect15.html#rtrue"><strong>rtrue</strong></a></td>
+    <td>RTRUE</td><td><a href="sect15.html#rtrue"><strong>rtrue</strong></a></td>
 </tr>
 
 <tr><td>     </td><td>    </td><td>  0OP:177</td><td>  1 </td><td>    </td><td>rfalse</td>
-    <td>XXX</td><td><a href="sect15.html#rfalse"><strong>rfalse</strong></a></td>
+    <td>RFALSE</td><td><a href="sect15.html#rfalse"><strong>rfalse</strong></a></td>
 </tr>
 
 <tr><td>     </td><td>    </td><td>  0OP:178</td><td>  2 </td><td>    </td>
-    <td>print           (literal-string)</td><td>XXX</td><td><a href="sect15.html#print"><strong>print           </strong></a></td>
+    <td>print           (literal-string)</td><td>PRINTI</td><td><a href="sect15.html#print"><strong>print           </strong></a></td>
 </tr>
 
 <tr><td>     </td><td>    </td><td>  0OP:179</td><td>  3 </td><td>    </td>
-    <td>print_ret       (literal-string)</td><td>XXX</td><td><a href="sect15.html#print_ret"><strong>print_ret       </strong></a></td>
+    <td>print_ret       (literal-string)</td><td>PRINTR</td><td><a href="sect15.html#print_ret"><strong>print_ret       </strong></a></td>
 </tr>
 
-<tr><td>     </td><td>    </td><td>  0OP:180</td><td>  4 </td><td>1/- </td><td>nop</td><td>XXX</td><td><a href="sect15.html#nop"><strong>nop</strong></a></td></tr>
+<tr><td>     </td><td>    </td><td>  0OP:180</td><td>  4 </td><td>1/- </td><td>nop</td><td>NOOP</td><td><a href="sect15.html#nop"><strong>nop</strong></a></td></tr>
 
 <tr><td>     </td><td>  * </td><td>  0OP:181</td><td>  5 </td><td> 1  </td>
-    <td>save            ?(label)</td><td>XXX</td><td><a href="sect15.html#save"><strong>save            </strong></a></td>
+    <td>save            ?(label)</td><td></td><td><a href="sect15.html#save"><strong>save            </strong></a></td>
 </tr>
 
 <tr><td>   * </td><td>    </td><td>        </td><td>     </td><td> 4  </td><td>save            -> (result)</td>
-    <td>XXX</td><td><a href="sect15.html#save"><strong>save            </strong></a></td>
+    <td></td><td><a href="sect15.html#save"><strong>save            </strong></a></td>
 </tr>
 
 <tr><td>     </td><td>    </td><td>        </td><td>     </td><td> 5  </td><td>[illegal]</td><td></td><td></td></tr>
 
 <tr><td>     </td><td>  * </td><td>  0OP:182</td><td>  6 </td><td> 1  </td><td>restore         ?(label)</td>
-    <td>XXX</td><td><a href="sect15.html#restore"><strong>restore         </strong></a></td>
+    <td></td><td><a href="sect15.html#restore"><strong>restore         </strong></a></td>
 </tr>
 
 <tr><td>   * </td><td>    </td><td>        </td><td>     </td><td> 4  </td><td>restore         -> (result)</td>
-    <td>XXX</td><td><a href="sect15.html#restore"><strong>restore         </strong></a></td>
+    <td></td><td><a href="sect15.html#restore"><strong>restore         </strong></a></td>
 </tr>
 
 <tr><td>     </td><td>    </td><td>        </td><td>     </td><td> 5  </td><td>[illegal]</td><td></td><td></td></tr>
 
 <tr><td>     </td><td>    </td><td>  0OP:183</td><td>  7 </td><td>    </td><td>restart</td>
-    <td>XXX</td><td><a href="sect15.html#restart"><strong>restart</strong></a></td>
+    <td>RESTART</td><td><a href="sect15.html#restart"><strong>restart</strong></a></td>
 </tr>
 
 <tr><td>     </td><td>    </td><td>  0OP:184</td><td>  8 </td><td>    </td><td>ret_popped</td>
-    <td>XXX</td><td><a href="sect15.html#ret_popped"><strong>ret_popped</strong></a></td>
+    <td>RSTACK</td><td><a href="sect15.html#ret_popped"><strong>ret_popped</strong></a></td>
 </tr>
 
 <tr><td>     </td><td>    </td><td>  0OP:185</td><td>  9 </td><td> 1  </td><td>pop</td>
-    <td>XXX</td><td><a href="sect15.html#pop"><strong>pop</strong></a></td>
+    <td></td><td><a href="sect15.html#pop"><strong>pop</strong></a></td>
 </tr>
 
 <tr><td>   * </td><td>    </td><td>        </td><td>     </td><td>5/6 </td><td>catch           -> (result)</td>
-    <td>XXX</td><td><a href="sect15.html#catch"><strong>catch           </strong></a></td>
+    <td>CATCH</td><td><a href="sect15.html#catch"><strong>catch           </strong></a></td>
 </tr>
 
 <tr><td>     </td><td>    </td><td>  0OP:186</td><td>  A </td><td>    </td><td>quit</td>
-    <td>XXX</td><td><a href="sect15.html#quit"><strong>quit</strong></a></td>
+    <td>QUIT</td><td><a href="sect15.html#quit"><strong>quit</strong></a></td>
 </tr>
 
 <tr><td>     </td><td>    </td><td>  0OP:187</td><td>  B </td><td>    </td><td>new_line</td>
-    <td>XXX</td><td><a href="sect15.html#new_line"><strong>new_line</strong></a></td>
+    <td>CRLF</td><td><a href="sect15.html#new_line"><strong>new_line</strong></a></td>
 </tr>
 
 <tr><td>     </td><td>    </td><td>  0OP:188</td><td>  C </td><td> 3  </td><td>show_status</td>
-    <td>XXX</td><td><a href="sect15.html#show_status"><strong>show_status</strong></a></td>
+    <td>USL</td><td><a href="sect15.html#show_status"><strong>show_status</strong></a></td>
 </tr>
 
 <tr><td>     </td><td>    </td><td>        </td><td>     </td><td> 4  </td><td>[illegal]</td><td></td><td></td></tr>
 
 <tr><td>     </td><td>  * </td><td>  0OP:189</td><td>  D </td><td> 3  </td><td>verify          ?(label)</td>
-    <td>XXX</td><td><a href="sect15.html#verify"><strong>verify          </strong></a></td>
+    <td>VERIFY</td><td><a href="sect15.html#verify"><strong>verify          </strong></a></td>
 </tr>
 
 <tr><td>     </td><td>    </td><td>  0OP:190</td><td>  E </td><td> 5  </td><td>[first byte of extended opcode]</td>
-    <td>XXX</td><td><a href="sect15.html#extended"><strong>extended</strong></a></td>
+    <td></td><td><a href="sect15.html#extended"><strong>extended</strong></a></td>
 </tr>
 
 <tr><td>     </td><td>  * </td><td>  0OP:191</td><td>  F </td><td>5/- </td><td>piracy          ?(label)</td>
-    <td>XXX</td><td><a href="sect15.html#piracy"><strong>piracy          </strong></a></td>
+    <td>ORIGINAL?</td><td><a href="sect15.html#piracy"><strong>piracy          </strong></a></td>
 </tr>
 
 <tr><td colspan="8" class="note">Opcode numbers 192 to 223: VAR forms of 2OP:0 to 2OP:31.</td></tr>

--- a/sect14.html
+++ b/sect14.html
@@ -511,127 +511,127 @@
 <tr><td>   St</td><td>  Br</td><td>  Opcode</td><td> Hex </td><td> V  </td><td>Inform name and syntax  </td><td>ZIL name</td><td>Link</td></tr>
 
 <tr><td>   * </td><td>    </td><td>  EXT:0 </td><td>   0 </td><td> 5  </td><td>save            table bytes name prompt -> (result)</td>
-    <td>XXX</td><td><a href="sect15.html#save"><strong>save            </strong></a></td>
+    <td>SAVE</td><td><a href="sect15.html#save"><strong>save            </strong></a></td>
 </tr>
 
 <tr><td>   * </td><td>    </td><td>  EXT:1 </td><td>   1 </td><td> 5  </td><td>restore         table bytes name prompt -> (result)</td>
-    <td>XXX</td><td><a href="sect15.html#restore"><strong>restore         </strong></a></td>
+    <td>RESTORE</td><td><a href="sect15.html#restore"><strong>restore         </strong></a></td>
 </tr>
 
 <tr><td>   * </td><td>    </td><td>  EXT:2 </td><td>   2 </td><td> 5  </td><td>log_shift       number places -> (result)</td>
-    <td>XXX</td><td><a href="sect15.html#log_shift"><strong>log_shift       </strong></a></td>
+    <td>SHIFT</td><td><a href="sect15.html#log_shift"><strong>log_shift       </strong></a></td>
 </tr>
 
 <tr><td>   * </td><td>    </td><td>  EXT:3 </td><td>   3 </td><td>5/- </td><td>art_shift       number places -> (result)</td>
-    <td>XXX</td><td><a href="sect15.html#art_shift"><strong>art_shift       </strong></a></td>
+    <td>ASHIFT</td><td><a href="sect15.html#art_shift"><strong>art_shift       </strong></a></td>
 </tr>
 
 <tr><td>   * </td><td>    </td><td>  EXT:4 </td><td>   4 </td><td> 5  </td><td>set_font        font -> (result)</td>
-    <td>XXX</td><td><a href="sect15.html#set_font"><strong>set_font        </strong></a></td>
+    <td>FONT</td><td><a href="sect15.html#set_font"><strong>set_font        </strong></a></td>
 </tr>
 
 <tr><td>   * </td><td>    </td><td></td><td>     </td><td> 6/-  </td><td>set_font        font window -> (result)</td>
-    <td>XXX</td><td><a href="sect15.html#set_font"><strong>set_font        </strong></a></td>
+    <td>FONT</td><td><a href="sect15.html#set_font"><strong>set_font        </strong></a></td>
 </tr>
 
 
 <tr><td>     </td><td>    </td><td>  EXT:5 </td><td>   5 </td><td> 6  </td><td>draw_picture    picture-number y x</td>
-    <td>XXX</td><td><a href="sect15.html#draw_picture"><strong>draw_picture    </strong></a></td>
+    <td>DISPLAY</td><td><a href="sect15.html#draw_picture"><strong>draw_picture    </strong></a></td>
 </tr>
 
 <tr><td>     </td><td>   *</td><td>  EXT:6 </td><td>   6 </td><td> 6  </td><td>picture_data    picture-number array ?(label)</td>
-    <td>XXX</td><td><a href="sect15.html#picture_data"><strong>picture_data    </strong></a></td>
+    <td>PICINF</td><td><a href="sect15.html#picture_data"><strong>picture_data    </strong></a></td>
 </tr>
 
 <tr><td>     </td><td>    </td><td>  EXT:7 </td><td>   7 </td><td> 6  </td><td>erase_picture   picture-number y x</td>
-    <td>XXX</td><td><a href="sect15.html#erase_picture"><strong>erase_picture   </strong></a></td>
+    <td>DCLEAR</td><td><a href="sect15.html#erase_picture"><strong>erase_picture   </strong></a></td>
 </tr>
 
 <tr><td>     </td><td>    </td><td>  EXT:8 </td><td>   8 </td><td> 6  </td><td>set_margins     left right window</td>
-    <td>XXX</td><td><a href="sect15.html#set_margins"><strong>set_margins     </strong></a></td>
+    <td>MARGIN</td><td><a href="sect15.html#set_margins"><strong>set_margins     </strong></a></td>
 </tr>
 
 <tr><td>   * </td><td>    </td><td>  EXT:9 </td><td>   9 </td><td> 5  </td><td>save_undo       -> (result)</td>
-    <td>XXX</td><td><a href="sect15.html#save_undo"><strong>save_undo       </strong></a></td>
+    <td>ISAVE</td><td><a href="sect15.html#save_undo"><strong>save_undo       </strong></a></td>
 </tr>
 
 <tr><td>   * </td><td>    </td><td>  EXT:10</td><td>   A </td><td> 5  </td><td>restore_undo    -> (result)</td>
-    <td>XXX</td><td><a href="sect15.html#restore_undo"><strong>restore_undo    </strong></a></td>
+    <td>IRESTORE</td><td><a href="sect15.html#restore_undo"><strong>restore_undo    </strong></a></td>
 </tr>
 
 <tr><td>     </td><td>    </td><td>  EXT:11</td><td>   B </td><td>5/* </td><td>print_unicode   char-number</td>
-    <td>XXX</td><td><a href="sect15.html#print_unicode"><strong>print_unicode   </strong></a></td>
+    <td>PRINTU</td><td><a href="sect15.html#print_unicode"><strong>print_unicode   </strong></a></td>
 </tr>
 
 <tr><td>   * </td><td>    </td><td>  EXT:12</td><td>   C </td><td>5/* </td><td>check_unicode   char-number -> (result)</td>
-    <td>XXX</td><td><a href="sect15.html#check_unicode"><strong>check_unicode   </strong></a></td>
+    <td>CHECKU</td><td><a href="sect15.html#check_unicode"><strong>check_unicode   </strong></a></td>
 </tr>
 
 <tr><td>     </td><td>    </td><td>  EXT:13</td><td>  D </td><td>5/* </td><td>set_true_colour foreground background</td>
-    <td>XXX</td><td><a href="sect15.html#set_true_colour"><strong>set_true_colour   </strong></a></td>
+    <td></td><td><a href="sect15.html#set_true_colour"><strong>set_true_colour   </strong></a></td>
 </tr>
 
 <tr><td>     </td><td>    </td><td>  </td><td>   </td><td>6/* </td><td>set_true_colour foreground background window</td>
-    <td>XXX</td><td><a href="sect15.html#set_true_colour"><strong>set_true_colour   </strong></a></td>
+    <td></td><td><a href="sect15.html#set_true_colour"><strong>set_true_colour   </strong></a></td>
 </tr>
 
 <tr><td>     </td><td>    </td><td>  -------</td><td>  E </td><td> ---</td><td>---</td><td></td><td></td></tr>
 <tr><td>     </td><td>    </td><td>  -------</td><td>  F </td><td> ---</td><td>---</td><td></td><td></td></tr>
 
 <tr><td>     </td><td>    </td><td>  EXT:16</td><td>  10 </td><td> 6  </td><td>move_window     window y x</td>
-    <td>XXX</td><td><a href="sect15.html#move_window"><strong>move_window     </strong></a></td>
+    <td>WINPOS</td><td><a href="sect15.html#move_window"><strong>move_window     </strong></a></td>
 </tr>
 
 <tr><td>     </td><td>    </td><td>  EXT:17</td><td>  11 </td><td> 6  </td><td>window_size     window y x</td>
-    <td>XXX</td><td><a href="sect15.html#window_size"><strong>window_size     </strong></a></td>
+    <td>WINSIZE</td><td><a href="sect15.html#window_size"><strong>window_size     </strong></a></td>
 </tr>
 
 <tr><td>     </td><td>    </td><td>  EXT:18</td><td>  12 </td><td> 6  </td><td>window_style    window flags operation</td>
-    <td>XXX</td><td><a href="sect15.html#window_style"><strong>window_style    </strong></a></td>
+    <td>WINATTR</td><td><a href="sect15.html#window_style"><strong>window_style    </strong></a></td>
 </tr>
 
 <tr><td>   * </td><td>    </td><td>  EXT:19</td><td>  13 </td><td> 6  </td><td>get_wind_prop   window property-number -> (result)</td>
-    <td>XXX</td><td><a href="sect15.html#get_wind_prop"><strong>get_wind_prop   </strong></a></td>
+    <td>WINGET</td><td><a href="sect15.html#get_wind_prop"><strong>get_wind_prop   </strong></a></td>
 </tr>
 
 <tr><td>     </td><td>    </td><td>  EXT:20</td><td>  14 </td><td> 6  </td><td>scroll_window   window pixels</td>
-    <td>XXX</td><td><a href="sect15.html#scroll_window"><strong>scroll_window   </strong></a></td>
+    <td>SCROLL</td><td><a href="sect15.html#scroll_window"><strong>scroll_window   </strong></a></td>
 </tr>
 
 <tr><td>     </td><td>    </td><td>  EXT:21</td><td>  15 </td><td> 6  </td><td>pop_stack       items stack</td>
-    <td>XXX</td><td><a href="sect15.html#pop_stack"><strong>pop_stack       </strong></a></td>
+    <td>FSTACK</td><td><a href="sect15.html#pop_stack"><strong>pop_stack       </strong></a></td>
 </tr>
 
 <tr><td>     </td><td>    </td><td>  EXT:22</td><td>  16 </td><td> 6  </td><td>read_mouse      array</td>
-    <td>XXX</td><td><a href="sect15.html#read_mouse"><strong>read_mouse      </strong></a></td>
+    <td>MOUSE-INFO</td><td><a href="sect15.html#read_mouse"><strong>read_mouse      </strong></a></td>
 </tr>
 
 <tr><td>     </td><td>    </td><td>  EXT:23</td><td>  17 </td><td> 6  </td><td>mouse_window    window</td>
-    <td>XXX</td><td><a href="sect15.html#mouse_window"><strong>mouse_window    </strong></a></td>
+    <td>MOUSE-LIMIT</td><td><a href="sect15.html#mouse_window"><strong>mouse_window    </strong></a></td>
 </tr>
 
 <tr><td>     </td><td>   *</td><td>  EXT:24</td><td>  18 </td><td> 6  </td><td>push_stack      value stack ?(label)</td>
-    <td>XXX</td><td><a href="sect15.html#push_stack"><strong>push_stack      </strong></a></td>
+    <td>XPUSH</td><td><a href="sect15.html#push_stack"><strong>push_stack      </strong></a></td>
 </tr>
 
 <tr><td>     </td><td>    </td><td>  EXT:25</td><td>  19 </td><td> 6  </td><td>put_wind_prop   window property-number value</td>
-    <td>XXX</td><td><a href="sect15.html#put_wind_prop"><strong>put_wind_prop   </strong></a></td>
+    <td>WINPUT</td><td><a href="sect15.html#put_wind_prop"><strong>put_wind_prop   </strong></a></td>
 </tr>
 
 <tr><td>     </td><td>    </td><td>  EXT:26</td><td>  1A </td><td> 6  </td><td>print_form      formatted-table</td>
-    <td>XXX</td><td><a href="sect15.html#print_form"><strong>print_form      </strong></a></td>
+    <td>PRINTF</td><td><a href="sect15.html#print_form"><strong>print_form      </strong></a></td>
 </tr>
 
 <tr><td>     </td><td>   *</td><td>  EXT:27</td><td>  1B </td><td> 6  </td><td>make_menu       number table ?(label)</td>
-    <td>XXX</td><td><a href="sect15.html#make_menu"><strong>make_menu       </strong></a></td>
+    <td>MENU</td><td><a href="sect15.html#make_menu"><strong>make_menu       </strong></a></td>
 </tr>
 
 <tr><td>     </td><td>    </td><td>  EXT:28</td><td>  1C </td><td> 6  </td><td>picture_table   table</td>
-    <td>XXX</td><td><a href="sect15.html#picture_table"><strong>picture_table   </strong></a></td>
+    <td>PICSET</td><td><a href="sect15.html#picture_table"><strong>picture_table   </strong></a></td>
 </tr>
 
 <tr><td>   * </td><td>    </td><td>  EXT:29</td><td>  1D </td><td> 6/*</td><td>buffer_screen mode -> (result)</td>
-    <td>XXX</td><td><a href="sect15.html#buffer_screen"><strong>buffer_screen   </strong></a></td>
+    <td></td><td><a href="sect15.html#buffer_screen"><strong>buffer_screen   </strong></a></td>
 </tr>
 
 </table>

--- a/sect14.html
+++ b/sect14.html
@@ -320,7 +320,7 @@
 </tr>
 
 <tr><td>     </td><td>    </td><td>  0OP:190</td><td>  E </td><td> 5  </td><td>[first byte of extended opcode]</td>
-    <td></td><td><a href="sect15.html#extended"><strong>extended</strong></a></td>
+    <td>EXTOP</td><td><a href="sect15.html#extended"><strong>extended</strong></a></td>
 </tr>
 
 <tr><td>     </td><td>  * </td><td>  0OP:191</td><td>  F </td><td>5/- </td><td>piracy          ?(label)</td>

--- a/sect14.html
+++ b/sect14.html
@@ -40,118 +40,118 @@
 <tr><td>     </td><td>    </td><td>  ------</td><td>   0 </td><td> ---</td><td>---</td><td></td><td></td></tr>
 
 <tr><td>     </td><td>  * </td><td>  2OP:1 </td><td>   1 </td><td>    </td>
-    <td>je              a b c d ?(label)</td><td>XXX</td><td><a href="sect15.html#je"><strong>je              </strong></a></td>
+    <td>je              a b c d ?(label)</td><td>EQUAL?</td><td><a href="sect15.html#je"><strong>je              </strong></a></td>
 </tr>
 
 <tr><td>     </td><td>  * </td><td>  2OP:2 </td><td>   2 </td><td>    </td>
-    <td>jl              a b ?(label)</td><td>XXX</td><td><a href="sect15.html#jl"><strong>jl              </strong></a></td>
+    <td>jl              a b ?(label)</td><td>LESS?</td><td><a href="sect15.html#jl"><strong>jl              </strong></a></td>
 </tr>
 
 <tr><td>     </td><td>  * </td><td>  2OP:3 </td><td>   3 </td><td>    </td><td>jg              a b ?(label)</td>
-    <td>XXX</td><td><a href="sect15.html#jg"><strong>jg              </strong></a></td>
+    <td>GRTR?</td><td><a href="sect15.html#jg"><strong>jg              </strong></a></td>
 </tr>
 
 <tr><td>     </td><td>  * </td><td>  2OP:4 </td><td>   4 </td><td>    </td><td>dec_chk         (variable) value ?(label)</td>
-    <td>XXX</td><td><a href="sect15.html#dec_chk"><strong>dec_chk         </strong></a></td>
+    <td>DLESS?</td><td><a href="sect15.html#dec_chk"><strong>dec_chk         </strong></a></td>
 </tr>
 
 <tr><td>     </td><td>  * </td><td>  2OP:5 </td><td>   5 </td><td>    </td><td>inc_chk         (variable) value ?(label)</td>
-    <td>XXX</td><td><a href="sect15.html#inc_chk"><strong>inc_chk         </strong></a></td>
+    <td>IGRTR?</td><td><a href="sect15.html#inc_chk"><strong>inc_chk         </strong></a></td>
 </tr>
 
 <tr><td>     </td><td>  * </td><td>  2OP:6 </td><td>   6 </td><td>    </td><td>jin             obj1 obj2 ?(label)</td>
-    <td>XXX</td><td><a href="sect15.html#jin"><strong>jin             </strong></a></td>
+    <td>IN?</td><td><a href="sect15.html#jin"><strong>jin             </strong></a></td>
 </tr>
 
 <tr><td>     </td><td>  * </td><td>  2OP:7 </td><td>   7 </td><td>    </td><td>test            bitmap flags ?(label)</td>
-    <td>XXX</td><td><a href="sect15.html#test"><strong>test            </strong></a></td>
+    <td>BTST</td><td><a href="sect15.html#test"><strong>test            </strong></a></td>
 </tr>
 
 <tr><td>   * </td><td>    </td><td>  2OP:8 </td><td>   8 </td><td>    </td><td>or              a b -> (result)</td>
-    <td>XXX</td><td><a href="sect15.html#or"><strong>or              </strong></a></td>
+    <td>BOR</td><td><a href="sect15.html#or"><strong>or              </strong></a></td>
 </tr>
 
 <tr><td>   * </td><td>    </td><td>  2OP:9 </td><td>   9 </td><td>    </td><td>and             a b -> (result)</td>
-    <td>XXX</td><td><a href="sect15.html#and"><strong>and             </strong></a></td>
+    <td>BAND</td><td><a href="sect15.html#and"><strong>and             </strong></a></td>
 </tr>
 
 <tr><td>     </td><td>  * </td><td>  2OP:10</td><td>   A </td><td>    </td><td>test_attr       object attribute ?(label)</td>
-    <td>XXX</td><td><a href="sect15.html#test_attr"><strong>test_attr       </strong></a></td>
+    <td>FSET?</td><td><a href="sect15.html#test_attr"><strong>test_attr       </strong></a></td>
 </tr>
 
 <tr><td>     </td><td>    </td><td>  2OP:11</td><td>   B </td><td>    </td><td>set_attr        object attribute</td>
-    <td>XXX</td><td><a href="sect15.html#set_attr"><strong>set_attr        </strong></a></td>
+    <td>FSET</td><td><a href="sect15.html#set_attr"><strong>set_attr        </strong></a></td>
 </tr>
 
 <tr><td>     </td><td>    </td><td>  2OP:12</td><td>   C </td><td>    </td><td>clear_attr      object attribute</td>
-    <td>XXX</td><td><a href="sect15.html#clear_attr"><strong>clear_attr      </strong></a></td>
+    <td>FCLEAR</td><td><a href="sect15.html#clear_attr"><strong>clear_attr      </strong></a></td>
 </tr>
 
 <tr><td>     </td><td>    </td><td>  2OP:13</td><td>   D </td><td>    </td><td>store           (variable) value</td>
-    <td>XXX</td><td><a href="sect15.html#store"><strong>store           </strong></a></td>
+    <td>SET</td><td><a href="sect15.html#store"><strong>store           </strong></a></td>
 </tr>
 
 <tr><td>     </td><td>    </td><td>  2OP:14</td><td>   E </td><td>    </td><td>insert_obj      object destination</td>
-    <td>XXX</td><td><a href="sect15.html#insert_obj"><strong>insert_obj      </strong></a></td>
+    <td>MOVE</td><td><a href="sect15.html#insert_obj"><strong>insert_obj      </strong></a></td>
 </tr>
 
 <tr><td>   * </td><td>    </td><td>  2OP:15</td><td>   F </td><td>    </td><td>loadw           array word-index -> (result)</td>
-    <td>XXX</td><td><a href="sect15.html#loadw"><strong>loadw           </strong></a></td>
+    <td>GET</td><td><a href="sect15.html#loadw"><strong>loadw           </strong></a></td>
 </tr>
 
 <tr><td>   * </td><td>    </td><td>  2OP:16</td><td>  10 </td><td>    </td><td>loadb           array byte-index -> (result)</td>
-    <td>XXX</td><td><a href="sect15.html#loadb"><strong>loadb           </strong></a></td>
+    <td>GETB</td><td><a href="sect15.html#loadb"><strong>loadb           </strong></a></td>
 </tr>
 
 <tr><td>   * </td><td>    </td><td>  2OP:17</td><td>  11 </td><td>    </td><td>get_prop        object property -> (result)</td>
-    <td>XXX</td><td><a href="sect15.html#get_prop"><strong>get_prop        </strong></a></td>
+    <td>GETP</td><td><a href="sect15.html#get_prop"><strong>get_prop        </strong></a></td>
 </tr>
 
 <tr><td>   * </td><td>    </td><td>  2OP:18</td><td>  12 </td><td>    </td><td>get_prop_addr   object property -> (result)</td>
-    <td>XXX</td><td><a href="sect15.html#get_prop_addr"><strong>get_prop_addr   </strong></a></td>
+    <td>GETPT</td><td><a href="sect15.html#get_prop_addr"><strong>get_prop_addr   </strong></a></td>
 </tr>
 
 <tr><td>   * </td><td>    </td><td>  2OP:19</td><td>  13 </td><td>    </td><td>get_next_prop   object property -> (result)</td>
-    <td>XXX</td><td><a href="sect15.html#get_next_prop"><strong>get_next_prop   </strong></a></td>
+    <td>NEXTP</td><td><a href="sect15.html#get_next_prop"><strong>get_next_prop   </strong></a></td>
 </tr>
 
 <tr><td>   * </td><td>    </td><td>  2OP:20</td><td>  14 </td><td>    </td><td>add             a b -> (result)</td>
-    <td>XXX</td><td><a href="sect15.html#add"><strong>add             </strong></a></td>
+    <td>ADD</td><td><a href="sect15.html#add"><strong>add             </strong></a></td>
 </tr>
 
 <tr><td>   * </td><td>    </td><td>  2OP:21</td><td>  15 </td><td>    </td><td>sub             a b -> (result)</td>
-    <td>XXX</td><td><a href="sect15.html#sub"><strong>sub             </strong></a></td>
+    <td>SUB</td><td><a href="sect15.html#sub"><strong>sub             </strong></a></td>
 </tr>
 
 <tr><td>   * </td><td>    </td><td>  2OP:22</td><td>  16 </td><td>    </td><td>mul             a b -> (result)</td>
-    <td>XXX</td><td><a href="sect15.html#mul"><strong>mul             </strong></a></td>
+    <td>MUL</td><td><a href="sect15.html#mul"><strong>mul             </strong></a></td>
 </tr>
 
 <tr><td>   * </td><td>    </td><td>  2OP:23</td><td>  17 </td><td>    </td><td>div             a b -> (result)</td>
-    <td>XXX</td><td><a href="sect15.html#div"><strong>div             </strong></a></td></tr>
+    <td>DIV</td><td><a href="sect15.html#div"><strong>div             </strong></a></td></tr>
 
 <tr><td>   * </td><td>    </td><td>  2OP:24</td><td>  18 </td><td>    </td><td>mod             a b -> (result)</td>
-    <td>XXX</td><td><a href="sect15.html#mod"><strong>mod             </strong></a></td>
+    <td>MOD</td><td><a href="sect15.html#mod"><strong>mod             </strong></a></td>
 </tr>
 
 <tr><td>   * </td><td>    </td><td>  2OP:25</td><td>  19 </td><td> 4  </td><td>call_2s         routine arg1 -> (result)</td>
-    <td>XXX</td><td><a href="sect15.html#call_2s"><strong>call_2s         </strong></a></td>
+    <td>CALL2</td><td><a href="sect15.html#call_2s"><strong>call_2s         </strong></a></td>
 </tr>
 
 <tr><td>     </td><td>    </td><td>  2OP:26</td><td>  1A </td><td> 5  </td><td>call_2n         routine arg1</td>
-    <td>XXX</td><td><a href="sect15.html#call_2n"><strong>call_2n         </strong></a></td>
+    <td>ICALL2</td><td><a href="sect15.html#call_2n"><strong>call_2n         </strong></a></td>
 </tr>
 
 <tr><td>     </td><td>    </td><td>  2OP:27</td><td>  1B </td><td> 5  </td><td>set_colour      foreground background</td>
-    <td>XXX</td><td><a href="sect15.html#set_colour"><strong>set_colour</strong></a></td>
+    <td>COLOR</td><td><a href="sect15.html#set_colour"><strong>set_colour</strong></a></td>
 </tr>
 
 <tr><td>     </td><td>    </td><td>        </td><td>     </td><td> 6  </td><td>set_colour      foreground background window</td>
-    <td>XXX</td><td><a href="sect15.html#set_colour"><strong>set_colour</strong></a></td>
+    <td>COLOR</td><td><a href="sect15.html#set_colour"><strong>set_colour</strong></a></td>
 </tr>
 
 <tr><td>     </td><td>    </td><td>  2OP:28</td><td>  1C </td><td>5/6 </td><td>throw           value stack-frame</td>
-    <td>XXX</td><td><a href="sect15.html#throw"><strong>throw           </strong></a></td>
+    <td>THROW</td><td><a href="sect15.html#throw"><strong>throw           </strong></a></td>
 </tr>
 
 <tr><td>     </td><td>    </td><td>  ------</td><td>  1D </td><td> ---</td><td>---</td><td></td><td></td></tr>


### PR DESCRIPTION
All known names from ZIL docs. (Really I looked at the ZILF source.)

Three are missing: 

- `@pop` (not `POP`!) is a v1 opcode which is not named in Infocom's ZIL docs.
- `@set_true_colour` and `@buffer_screen` are spec-1.1 opcodes which have not been adopted or named by ZILF.

